### PR TITLE
Add status management for players and storytellers

### DIFF
--- a/app/assets/javascripts/characters.js
+++ b/app/assets/javascripts/characters.js
@@ -142,6 +142,6 @@ $('.dot').on('click', function(e) {
 
 $('#save-submit').on('click', function(e) {
   e.preventDefault();
-  $('#submit').val(true);
+  $('#status').val(1);
   $('form').submit();
 });

--- a/app/assets/javascripts/characters.js
+++ b/app/assets/javascripts/characters.js
@@ -139,3 +139,9 @@ $('.dot').on('click', function(e) {
     $(this).find('input').change();
   }
 });
+
+$('#save-submit').on('click', function(e) {
+  e.preventDefault();
+  $('#submit').val(true);
+  $('form').submit();
+});

--- a/app/controllers/characters_controller.rb
+++ b/app/controllers/characters_controller.rb
@@ -1,11 +1,9 @@
 class CharactersController < ApplicationController
 	before_action :authenticate_user!
 
-	helper_method :get_status
-
 	ATTRIBUTES = {"Mental": ["Intelligence", "Wits", "Resolve"], "Physical": ["Strength", "Dexterity", "Stamina"], "Social": ["Presence", "Manipulation", "Composure"]}
 	SKILLS_TRAINING = {"Skills": ["Artsy", "Athletics", "Bureaucracy", "Drive", "Empathy", "Fight", "Guns", "Handy", "Intimidation", "Lies", "Outdoorsy", "Persuasion", "Religion", "Stealth", "Theft"], "Special Training": ["Academics", "Computers", "Engineering", "Investigation", "Law", "Local Lore", "Medicine", "Science"]}
-	STATUS_ENUM = ["Editing", "Submitted", "Active", "Inactive"]
+	STATUS_ENUM = [["In Progress", 0], ["Submitted", 1], ["Active", 2], ["Inactive", 3]]
 
 	def index
 		if current_user.is_storyteller
@@ -35,6 +33,7 @@ class CharactersController < ApplicationController
 		@advantages = Advantage.all
 		@challenges = Challenge.all
 		@player = current_user
+		@statuses = STATUS_ENUM
 		@questionnaire_sections = QuestionnaireSection.all.order(order: :asc)
 		if !@character.use_extended
 			@questionnaire = @questionnaire.to_a.reject!{|q| q.questionnaire_items.where(extended: false).empty?}
@@ -58,6 +57,7 @@ class CharactersController < ApplicationController
 		@challenges = Challenge.all
 		@player = @character.user
 		@questionnaire_sections = QuestionnaireSection.all.order(order: :asc)
+		@statuses = STATUS_ENUM
 		if !@character.use_extended
 			@questionnaire = @questionnaire.to_a.reject!{|q| q.questionnaire_items.where(extended: false).empty?}
 		end
@@ -302,10 +302,6 @@ class CharactersController < ApplicationController
 	protected
 
 	def characters_params
-		params.require(:character).permit(:name, :user_id, :true_self_id, :stability, :handy, :religion, :bureaucracy, :athletics, :fight, :drive, :guns, :theft, :stealth, :outdoorsy, :empathy, :artsy, :intimidation, :persuasion, :lies, :academics, :investigation, :medicine, :local_lore, :law, :science, :computers, :engineering, :public_blurb, :willpower, :defense, :speed, :intelligence, :wits, :resolve, :strength, :dexterity, :stamina, :presence, :manipulation, :composure, :speed, :initiative, :willpower, :health, :defense, :pronouns, :use_extended)
-	end
-
-	def get_status(status)
-		STATUS_ENUM[status]
+		params.require(:character).permit(:name, :user_id, :status, :true_self_id, :stability, :handy, :religion, :bureaucracy, :athletics, :fight, :drive, :guns, :theft, :stealth, :outdoorsy, :empathy, :artsy, :intimidation, :persuasion, :lies, :academics, :investigation, :medicine, :local_lore, :law, :science, :computers, :engineering, :public_blurb, :willpower, :defense, :speed, :intelligence, :wits, :resolve, :strength, :dexterity, :stamina, :presence, :manipulation, :composure, :speed, :initiative, :willpower, :health, :defense, :pronouns, :use_extended)
 	end
 end

--- a/app/controllers/characters_controller.rb
+++ b/app/controllers/characters_controller.rb
@@ -70,6 +70,9 @@ class CharactersController < ApplicationController
 
 	def update
 		@character = Character.find(params[:id])
+		if params[:submit].present? && params[:submit]
+			@character.status = 1
+		end
 		if @character.update_attributes!(characters_params)
 			flash[:success] = "Changes to your character were saved."
 			if params[:character][:character_has_challenges].present?

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -10,4 +10,12 @@ class Character < ApplicationRecord
 	accepts_nested_attributes_for :questionnaire_answers, :character_has_challenges, :character_has_advantages
 
 	validates :user, presence: true
+
+	def get_status
+		return STATUS[self.status]
+	end
+
+	private
+
+	STATUS = ["In Progress", "Submitted", "Active", "Inactive"]
 end

--- a/app/views/characters/_form.slim
+++ b/app/views/characters/_form.slim
@@ -1,6 +1,10 @@
 .form-row
   = f.label :name
   = f.text_field :name
+- if current_user.is_storyteller
+  .form-row
+    = f.label :status
+    = f.select :status, options_for_select(@statuses)
 .form-row
   = f.label :pronouns, "Character Pronouns"
   = f.text_field :pronouns
@@ -132,7 +136,11 @@ h3 Questionnaire
                 = hidden_field_tag "character[questionnaire_answers][][id]"
               = hidden_field_tag "character[questionnaire_answers][][questionnaire_item_id]", question.id
 
+= hidden_field_tag "submit", false
+
 = f.submit "Save"
+- if @character.status == 0
+  = f.submit "Save and Submit", id: 'save-submit'
 
 .overlay#advantages-overlay
   .modal

--- a/app/views/characters/_form.slim
+++ b/app/views/characters/_form.slim
@@ -4,7 +4,7 @@
 - if current_user.is_storyteller
   .form-row
     = f.label :status
-    = f.select :status, options_for_select(@statuses)
+    = f.select :status, options_for_select(@statuses, @character.status)
 .form-row
   = f.label :pronouns, "Character Pronouns"
   = f.text_field :pronouns
@@ -136,10 +136,11 @@ h3 Questionnaire
                 = hidden_field_tag "character[questionnaire_answers][][id]"
               = hidden_field_tag "character[questionnaire_answers][][questionnaire_item_id]", question.id
 
-= hidden_field_tag "submit", false
+
 
 = f.submit "Save"
-- if @character.status == 0
+- if @character.status == 0 and (current_user == @character.user or @character.user.nil?)
+  = hidden_field_tag "status", @character.status
   = f.submit "Save and Submit", id: 'save-submit'
 
 .overlay#advantages-overlay

--- a/app/views/characters/index.slim
+++ b/app/views/characters/index.slim
@@ -13,6 +13,7 @@
         th Name
         - if current_user.is_storyteller?
           th Player Name
+        th Status
         th
         th
     tbody
@@ -23,6 +24,8 @@
           - if current_user.is_storyteller?
             td
               = character.user.name
+          td
+            = character.get_status
           td
             = link_to "Edit", edit_character_path(character)
           td

--- a/app/views/characters/show.slim
+++ b/app/views/characters/show.slim
@@ -5,6 +5,9 @@ h2
   strong Name
   = @character.name
 .form-row
+  strong Status
+  = @character.get_status
+.form-row
   strong Character Pronouns
   = @character.pronouns
 .form-row


### PR DESCRIPTION
* Gives players the ability to submit their character by pressing the "save and submit" button at the bottom of the character form
* Gives storytellers the ability to manage any character's status with a select box near the top of the page

Closes https://tree.taiga.io/project/stephmarx-ask-again-later-character-system/task/53?kanban-status=856838