### PR TITLE
Add description field for true selves, plus API endpoints

### DIFF
--- a/app/controllers/api/true_selves_controller.rb
+++ b/app/controllers/api/true_selves_controller.rb
@@ -1,0 +1,15 @@
+require 'json'
+
+module Api
+  class TrueSelvesController < ApplicationController
+    def index
+      @true_selves = TrueSelf.all.order(:name)
+      render json: @true_selves.to_json
+    end
+
+    def show
+      @true_self = TrueSelf.find(params[:id])
+      render json: @true_self.to_json
+    end
+  end
+end

--- a/app/views/storytellers/true_selves/_form.slim
+++ b/app/views/storytellers/true_selves/_form.slim
@@ -1,6 +1,9 @@
 .form-row
   = f.label :name
   = f.text_field :name
+.form-row
+  = f.label :description
+  = f.text_area :description
 
 .form-row
   = f.submit "Save", class: 'button'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,9 @@ Rails.application.routes.draw do
 
     get 'challenges', to: 'challenges#index'
     get 'challenges/:id', to: 'challenges#show'
+
+    get 'true_selves', to: 'true_selves#index'
+    get 'true_selves/:id', to: 'true_selves#show'
   end
 
   namespace :admin do

--- a/db/migrate/20170311212541_add_description_for_true_selves.rb
+++ b/db/migrate/20170311212541_add_description_for_true_selves.rb
@@ -1,0 +1,5 @@
+class AddDescriptionForTrueSelves < ActiveRecord::Migration[5.0]
+  def change
+    add_column :true_selves, :description, :text, default: ''
+  end
+end


### PR DESCRIPTION
* Adds a description field for True Selves
* Adds a box to enter the description to the True Self forms
* Creates an API endpoint to return all True Selves
* Creates an API endpoint to return a single True Self

Closes https://tree.taiga.io/project/stephmarx-ask-again-later-character-system/task/140?kanban-status=856836
Closes https://tree.taiga.io/project/stephmarx-ask-again-later-character-system/task/141?kanban-status=856836