### PR TITLE
Add ability to create create custom Challenges

### DIFF
--- a/app/assets/javascripts/characters.js
+++ b/app/assets/javascripts/characters.js
@@ -114,15 +114,54 @@ $('#challenge-add').on('click', function(e) {
   var name = $selected.text();
   var challengeId = $selected.val();
 
-  $('ul#challenges-list').append('<li data-challenge-id="'+challengeId+'">'+name+'<a href="#" class="challenge-delete"><i class="fa fa-minus-circle"></i></a><div class="description"></div><input type="hidden" name="character[character_has_challenges][][id]" value="" /><input type="hidden" name="character[character_has_challenges][][challenge_id]" value="'+challengeId+'" /></li>');
+  $('ul#challenges-list').append('<li data-challenge-id="'+challengeId+'"><span class="custom-name">'+name+'</span> <a href="#" class="challenge-delete"><i class="fa fa-minus-circle"></i></a><div class="description"></div><input type="hidden" name="character[character_has_challenges][][id]" value="" /><input type="hidden" name="character[character_has_challenges][][challenge_id]" value="'+challengeId+'" /></li>');
 
   $.ajax({
     url: '/api/challenges/'+challengeId,
     method: 'GET',
     success: function(data) {
       $('#challenges-list li').last().find('.description').html(data.description);
+      if (data.is_custom) {
+        $('#challenges-list li').last().find('.challenge-delete').before('<a href="#" class="challenge-edit"><i class="fa fa-edit"></i></a>');
+      }
     }
   });
+});
+
+$('#challenges-list').delegate('.challenge-edit', 'click', function(e) {
+  e.preventDefault();
+  var $modal = $('#challenges-overlay .modal');
+  var $challenge = $(this).parent('li');
+  var index = $challenge.index();
+  var challengeId = $challenge.find('input[name="character[character_has_challenges][][challenge_id]"]').val();
+  var name = $challenge.find('input[name="character[character_has_challenges][][custom_name]"]').val();
+  var description = $challenge.find('input[name="character[character_has_challenges][][custom_description]"]').val();
+
+  $modal.find('#modal-custom-name').val(name);
+  $modal.find('#modal-custom-description').text(description);
+
+  $modal.find('#modal-chc-id').val(index);
+
+  $('.overlay').fadeIn().css("display", "flex");
+});
+
+$('#save-challenge').on('click', function(e) {
+  var $modal = $('#challenges-overlay .modal');
+  var name = $modal.find('#modal-custom-name').val();
+  var description = $modal.find('#modal-custom-description').val();
+  var challengeToUpdate = $modal.find('#modal-chc-id').val();
+  var $challenge = $('#challenges-list li:nth-child('+(parseInt(challengeToUpdate)+1)+')');
+  // update both display and hidden field values
+
+  $challenge.find('.custom-name').text(name);
+  $challenge.find('input[name="character[character_has_challenges][][custom_name]"]').val(name);
+  $challenge.find('.description').html(description);
+  $challenge.find('input[name="character[character_has_challenges][][custom_description]"]').val(description);
+  $('.overlay').fadeOut();
+});
+
+$('#cancel-challenge').on('click', function(e) {
+  $('.overlay').fadeOut();
 });
 
 $('#challenges-list').delegate('.challenge-delete', 'click', function(e) {

--- a/app/controllers/characters_controller.rb
+++ b/app/controllers/characters_controller.rb
@@ -80,10 +80,12 @@ class CharactersController < ApplicationController
 				# add new challenges, and catalog all the challenges that should be on the sheet
 				params[:character][:character_has_challenges].each do |challenge|
 					unless challenge[:id].present?
-						@challenge = CharacterHasChallenge.new(character_id: @character.id, challenge_id: challenge[:challenge_id])
+						@challenge = CharacterHasChallenge.new(character_id: @character.id, challenge_id: challenge[:challenge_id], custom_name: challenge[:custom_name], custom_description: challenge[:custom_description])
 						@challenge.save!
 						chc_ids << @challenge.id.to_i
 					else
+						@challenge = CharacterHasChallenge.find(challenge[:id])
+						@challenge.update_attributes!(custom_name: challenge[:custom_name], custom_description: challenge[:custom_description])
 						chc_ids << challenge[:id].to_i
 					end
 				end
@@ -164,10 +166,12 @@ class CharactersController < ApplicationController
 				# add new challenges, and catalog all the challenges that should be on the sheet
 				params[:character][:character_has_challenges].each do |challenge|
 					unless challenge[:id].present?
-						@challenge = CharacterHasChallenge.new(character_id: @character.id, challenge_id: challenge[:challenge_id])
+						@challenge = CharacterHasChallenge.new(character_id: @character.id, challenge_id: challenge[:challenge_id], custom_name: challenge[:custom_name], custom_description: challenge[:custom_description])
 						@challenge.save!
 						chc_ids << @challenge.id.to_i
 					else
+						@challenge = CharacterHasChallenge.find(challenge[:id])
+						@challenge.update_attributes!(custom_name: challenge[:custom_name], custom_description: challenge[:custom_description])
 						chc_ids << challenge[:id].to_i
 					end
 				end

--- a/app/controllers/storytellers/challenges_controller.rb
+++ b/app/controllers/storytellers/challenges_controller.rb
@@ -43,7 +43,7 @@ module Storytellers
     private
 
     def challenges_params
-      params.require(:challenge).permit(:id, :name, :description, :is_creature_challenge)
+      params.require(:challenge).permit(:id, :name, :description, :is_creature_challenge, :is_custom)
     end
   end
 end

--- a/app/views/characters/_form.slim
+++ b/app/views/characters/_form.slim
@@ -84,19 +84,32 @@ h3 Challenges
 
 select name="challenges" id="challenges"
   - @challenges.each do |challenge|
-    option value="#{challenge.id}" #{challenge.name}
+    option value="#{challenge.id}" data-is-custom="#{challenge.is_custom}" #{challenge.name}
 = button_tag 'Add', type: 'button', class: 'button', id: "challenge-add"
 
 ul#challenges-list
   - @character.character_has_challenges.each do |challenge|
     li
-      = "#{challenge.challenge.name} "
+      - if challenge.challenge.is_custom
+        - if challenge.custom_name.present?
+          = "<span class='custom-name'>#{challenge.custom_name}</span> ".html_safe
+        - else
+          = "<span class='custom-name'>#{challenge.challenge.name}</span> ".html_safe
+      - else
+        = "#{challenge.challenge.name} "
+      - if challenge.challenge.is_custom
+        = link_to "<i class='fa fa-edit'></i>".html_safe, "#", class: 'challenge-edit'
       = link_to "<i class='fa fa-minus-circle'></i>".html_safe, "#", class: 'challenge-delete'
-      - if challenge.challenge.description.present?
+      - if challenge.custom_description.present?
+        .description
+          = challenge.custom_description.html_safe
+      - elsif challenge.challenge.description.present?
         .description
           = challenge.challenge.description.html_safe
       = hidden_field_tag "character[character_has_challenges][][id]", challenge.id
       = hidden_field_tag "character[character_has_challenges][][challenge_id]", challenge.challenge.id
+      = hidden_field_tag "character[character_has_challenges][][custom_name]", challenge.custom_name
+      = hidden_field_tag "character[character_has_challenges][][custom_description]", challenge.custom_description
 
 h3 Derived Stats
 .form-row
@@ -164,5 +177,25 @@ h3 Questionnaire
       .form-row
         = button_tag "Save", type: 'button', class: 'button', id: 'save-advantage'
         = button_tag "Cancel", type: 'button', class: 'button', id: 'cancel-advantage'
+
+.overlay#challenges-overlay
+  .modal
+    .header
+      | Edit Challenge:
+      span
+    .content
+      .form-row.name
+        = label_tag :custom_name, "Name"
+        = text_field_tag :custom_name, "", id: 'modal-custom-name'
+
+      .form-row.description
+        = label_tag :custom_description, "Description"
+        = text_area_tag :custom_description, "", id: 'modal-custom-description'
+
+      = hidden_field_tag :chc_id, "", id: 'modal-chc-id'
+
+      .form-row
+        = button_tag "Save", type: 'button', class: 'button', id: 'save-challenge'
+        = button_tag "Cancel", type: 'button', class: 'button', id: 'cancel-challenge'
 
 = javascript_include_tag 'characters', 'data-turbolinks-track' => true

--- a/app/views/characters/show.slim
+++ b/app/views/characters/show.slim
@@ -78,13 +78,19 @@ ul#advantages
 
 h3 Challenges
 
-ul#advantages
+ul#challenges
   - @character.character_has_challenges.each do |chc|
     li
       p.name
-        = chc.challenge.name
+        - if chc.challenge.is_custom and chc.custom_name.present?
+          = chc.custom_name
+        - else
+          = chc.challenge.name
       p.desc
-        = chc.challenge.description
+        - if chc.challenge.is_custom and chc.custom_description.present?
+          = chc.custom_description.html_safe
+        - else
+          = chc.challenge.description.html_safe
 
 h3 Derived Stats
 

--- a/app/views/characters/wizard_challenges_advantages.slim
+++ b/app/views/characters/wizard_challenges_advantages.slim
@@ -30,19 +30,32 @@
 
   select name="challenges" id="challenges"
     - @challenges.each do |challenge|
-      option value="#{challenge.id}" #{challenge.name}
+      option value="#{challenge.id}" data-is-custom="#{challenge.is_custom}" #{challenge.name}
   = button_tag 'Add', type: 'button', class: 'button', id: "challenge-add"
 
   ul#challenges-list
     - @character.character_has_challenges.each do |challenge|
       li
-        = "#{challenge.challenge.name} "
+        - if challenge.challenge.is_custom
+          - if challenge.custom_name.present?
+            = "<span class='custom-name'>#{challenge.custom_name}</span> ".html_safe
+          - else
+            = "<span class='custom-name'>#{challenge.challenge.name}</span> ".html_safe
+        - else
+          = "#{challenge.challenge.name} "
+        - if challenge.challenge.is_custom
+          = link_to "<i class='fa fa-edit'></i>".html_safe, "#", class: 'challenge-edit'
         = link_to "<i class='fa fa-minus-circle'></i>".html_safe, "#", class: 'challenge-delete'
-        - if challenge.challenge.description.present?
+        - if challenge.custom_description.present?
+          .description
+            = challenge.custom_description.html_safe
+        - elsif challenge.challenge.description.present?
           .description
             = challenge.challenge.description.html_safe
         = hidden_field_tag "character[character_has_challenges][][id]", challenge.id
         = hidden_field_tag "character[character_has_challenges][][challenge_id]", challenge.challenge.id
+        = hidden_field_tag "character[character_has_challenges][][custom_name]", challenge.custom_name
+        = hidden_field_tag "character[character_has_challenges][][custom_description]", challenge.custom_description
 
   = hidden_field_tag "wizard_current", "challenges_advantages"
   = hidden_field_tag "wizard_prev", "skills_trainings"
@@ -73,6 +86,26 @@
       .form-row
         = button_tag "Save", type: 'button', class: 'button', id: 'save-advantage'
         = button_tag "Cancel", type: 'button', class: 'button', id: 'cancel-advantage'
+
+.overlay#challenges-overlay
+  .modal
+    .header
+      | Edit Challenge:
+      span
+    .content
+      .form-row.name
+        = label_tag :custom_name, "Name"
+        = text_field_tag :custom_name, "", id: 'modal-custom-name'
+
+      .form-row.description
+        = label_tag :custom_description, "Description"
+        = text_area_tag :custom_description, "", id: 'modal-custom-description'
+
+      = hidden_field_tag :chc_id, "", id: 'modal-chc-id'
+
+      .form-row
+        = button_tag "Save", type: 'button', class: 'button', id: 'save-challenge'
+        = button_tag "Cancel", type: 'button', class: 'button', id: 'cancel-challenge'
 
 = javascript_include_tag 'wizard', 'data-turbolinks-track' => true
 = javascript_include_tag 'characters', 'data-turbolinks-track' => true

--- a/app/views/storytellers/challenges/_form.slim
+++ b/app/views/storytellers/challenges/_form.slim
@@ -11,4 +11,8 @@
   = f.check_box :is_creature_challenge
 
 .form-row
+  = f.label :is_custom, "Is Custom Challenge?"
+  = f.check_box :is_custom
+
+.form-row
   = f.submit "Save", class: 'button'

--- a/db/migrate/20170128192807_create_challenges.rb
+++ b/db/migrate/20170128192807_create_challenges.rb
@@ -4,6 +4,7 @@ class CreateChallenges < ActiveRecord::Migration[5.0]
     	t.string :name
     	t.text :description
     	t.boolean :is_creature_challenge
+      t.boolean :is_custom
       t.timestamps
     end
   end

--- a/db/migrate/201702010636081_create_character_has_challenges.rb
+++ b/db/migrate/201702010636081_create_character_has_challenges.rb
@@ -3,6 +3,8 @@ class CreateCharacterHasChallenges < ActiveRecord::Migration[5.0]
     create_table :character_has_challenges do |t|
       t.references :character, index: true, foreign_key: true, null: false
       t.references :challenge, index: true, foreign_key: true, null: false
+      t.string :custom_name
+      t.text :custom_description
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -31,6 +31,7 @@ ActiveRecord::Schema.define(version: 201702020635481) do
     t.boolean  "is_creature_challenge"
     t.datetime "created_at",            null: false
     t.datetime "updated_at",            null: false
+    t.boolean  "is_custom"
   end
 
   create_table "character_has_advantages", force: :cascade do |t|
@@ -45,10 +46,12 @@ ActiveRecord::Schema.define(version: 201702020635481) do
   end
 
   create_table "character_has_challenges", force: :cascade do |t|
-    t.integer  "character_id", null: false
-    t.integer  "challenge_id", null: false
-    t.datetime "created_at",   null: false
-    t.datetime "updated_at",   null: false
+    t.integer  "character_id",       null: false
+    t.integer  "challenge_id",       null: false
+    t.datetime "created_at",         null: false
+    t.datetime "updated_at",         null: false
+    t.string   "custom_name"
+    t.text     "custom_description"
     t.index ["challenge_id"], name: "index_character_has_challenges_on_challenge_id", using: :btree
     t.index ["character_id"], name: "index_character_has_challenges_on_character_id", using: :btree
   end
@@ -116,7 +119,7 @@ ActiveRecord::Schema.define(version: 201702020635481) do
   end
 
   create_table "questionnaire_items", force: :cascade do |t|
-    t.string   "question",   null: false
+    t.string   "question",                                 null: false
     t.integer  "order"
     t.datetime "created_at",                               null: false
     t.datetime "updated_at",                               null: false
@@ -134,9 +137,10 @@ ActiveRecord::Schema.define(version: 201702020635481) do
   end
 
   create_table "true_selves", force: :cascade do |t|
-    t.string   "name",       null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.string   "name",                     null: false
+    t.datetime "created_at",               null: false
+    t.datetime "updated_at",               null: false
+    t.text     "description", default: ""
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
Added an option to create a customizable Challenge. This is indicated in Challenge creation by ticking the box marked "is custom challenge?" When this challenge is selected on a character sheet, it will add an "edit" option, which should pop up a modal similar to the advantage modal that will allow entry of a custom name and description. When the custom name and/or description are present, they will override the base challenge's name and description on the character sheet.