### PR TITLE
Fix logout link by turning it into a form with a button sneakily

### DIFF
--- a/app/assets/stylesheets/components/_header.scss
+++ b/app/assets/stylesheets/components/_header.scss
@@ -31,7 +31,20 @@ header {
       > li {
         position: relative;
 
-        > a, > span {
+        > form button {
+          background-color: transparent;
+          font-size: 16px;
+          font-family: 'Roboto', sans-serif;
+          border: none;
+          padding: 0;
+          cursor: pointer;
+
+          &:focus {
+            outline: none;
+          }
+        }
+
+        > a, > span, > form button {
           text-decoration: none;
           color: $white;
           height: auto;

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -16,7 +16,7 @@
         <% end %>
         <li><a href="http://askagainlater.com/" rel="external" target="_blank">Info Site</a></li>
         <% if current_user %>
-          <li><%= link_to "Log Out", destroy_user_session_path %></li>
+          <li><%= form_tag(destroy_user_session_path, method: 'DELETE') do %><button type="submit" class="nav-link">Log Out</button><% end %></li>
         <% else %>
           <li><%= link_to "Log In", new_user_session_path %></li>
           <li><%= link_to "Create an Account", new_user_registration_path %></li>


### PR DESCRIPTION
the logout path requires being used with the 'DELETE' method, rather than a simple GET request. As such, we need to submit it via a form. I have sneakily inserted a tiny form and turned the link into a button. Clicking the button should a) not look like you're clicking a button and b) log you out now.