### PR TITLE
[33] Fixes clipped background image on devise pages

### DIFF
--- a/app/assets/stylesheets/pages/devise.scss
+++ b/app/assets/stylesheets/pages/devise.scss
@@ -1,7 +1,11 @@
-.devise-page {
-  flex: 1;
+.main.devise {
+  max-width: none;
   background-image: url('/assets/misty-woods.jpg');
   background-size: cover;
+}
+
+.devise-page {
+  flex: 1;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,7 +8,7 @@
 </head>
 <body>
   <%= render partial: 'layouts/header' %>
-  <div class="main">
+  <div class="main<%= devise_controller? ? ' devise' : '' %>">
     <%= yield %>
   </div>
   <%= javascript_include_tag 'footer', 'data-turbolinks-track' => true %>


### PR DESCRIPTION
Closes #33.

I used the devise_controller? method to add a class to the .main div when the page is generated by a devise controller, which removes the max-width and applies the background image.