### PR TITLE
Add link to storyteller tools section for STs

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -12,6 +12,9 @@
               <li><%= link_to "Create New", new_character_path %></li>
             </ul>
           </li>
+          <% if current_user.is_storyteller %>
+            <li><%= link_to "Tools", storytellers_path %></li>
+          <% end %>
           <li><%= link_to "Settings", edit_user_registration_path %></li>
         <% end %>
         <li><a href="http://askagainlater.com/" rel="external" target="_blank">Info Site</a></li>

--- a/app/views/storytellers/dashboard/index.slim
+++ b/app/views/storytellers/dashboard/index.slim
@@ -2,6 +2,8 @@ h2 Storyteller Dashboard
 
 ul
   li
+    = link_to "Print Character Sheets", characters_print_path, target: '_blank'
+  li
     = link_to "Advantages", storytellers_advantages_path
   li
     = link_to "Challenges", storytellers_challenges_path


### PR DESCRIPTION
Adds a link in the navbar for logged-in storytellers called "Tools", and takes you to a link where you can do data entry and print all the character sheets.