### PR TITLE
[35] Changes to Challenge Addition

### DIFF
--- a/app/assets/javascripts/characters.js
+++ b/app/assets/javascripts/characters.js
@@ -121,9 +121,21 @@ $('#challenge-add').on('click', function(e) {
     method: 'GET',
     success: function(data) {
       $('#challenges-list li').last().find('.description').html(data.description);
-      if (data.is_custom) {
-        $('#challenges-list li').last().find('.challenge-delete').before('<a href="#" class="challenge-edit"><i class="fa fa-edit"></i></a>');
-      }
+    }
+  });
+});
+
+$('#challenge-add-custom').on('click', function(e) {
+  e.preventDefault();
+  var id = $(this).data('challenge-id');
+
+  $('ul#challenges-list').append('<li data-challenge-id="'+id+'"><span class="custom-name"></span> <a href="#" class="challenge-edit"><i class="fa fa-edit"></i></a> <a href="#" class="challenge-delete"><i class="fa fa-minus-circle"></i></a><div class="description"></div><input type="hidden" name="character[character_has_challenges][][id]" value="" /><input type="hidden" name="character[character_has_challenges][][challenge_id]" value="'+id+'" /></li>');
+
+  $.ajax({
+    url: '/api/challenges/'+id,
+    method: 'GET',
+    success: function(data) {
+      $('#challenges-list li').last().find('.custom-name').html(data.name);
     }
   });
 });

--- a/app/assets/javascripts/characters.js
+++ b/app/assets/javascripts/characters.js
@@ -114,13 +114,14 @@ $('#challenge-add').on('click', function(e) {
   var name = $selected.text();
   var challengeId = $selected.val();
 
-  $('ul#challenges-list').append('<li data-challenge-id="'+challengeId+'"><span class="custom-name">'+name+'</span> <a href="#" class="challenge-delete"><i class="fa fa-minus-circle"></i></a><div class="description"></div><input type="hidden" name="character[character_has_challenges][][id]" value="" /><input type="hidden" name="character[character_has_challenges][][challenge_id]" value="'+challengeId+'" /></li>');
+  $('ul#challenges-list').append('<li data-challenge-id="'+challengeId+'"><span class="custom-name">'+name+'</span> <a href="#" class="challenge-delete"><i class="fa fa-minus-circle"></i></a><div class="description"></div><input type="hidden" name="character[character_has_challenges][][id]" value="" /><input type="hidden" name="character[character_has_challenges][][challenge_id]" value="'+challengeId+'" /><input type="hidden" name="character[character_has_challenges][][is_creature_challenge]" value="true" /></li>');
 
   $.ajax({
     url: '/api/challenges/'+challengeId,
     method: 'GET',
     success: function(data) {
       $('#challenges-list li').last().find('.description').html(data.description);
+      $('#challenges-list li').data('is-creature', data.is_creature_challenge)
     }
   });
 });
@@ -129,7 +130,7 @@ $('#challenge-add-custom').on('click', function(e) {
   e.preventDefault();
   var id = $(this).data('challenge-id');
 
-  $('ul#challenges-list').append('<li data-challenge-id="'+id+'"><span class="custom-name"></span> <a href="#" class="challenge-edit"><i class="fa fa-edit"></i></a> <a href="#" class="challenge-delete"><i class="fa fa-minus-circle"></i></a><div class="description"></div><input type="hidden" name="character[character_has_challenges][][id]" value="" /><input type="hidden" name="character[character_has_challenges][][challenge_id]" value="'+id+'" /></li>');
+  $('ul#challenges-list').append('<li data-challenge-id="'+id+'"><span class="custom-name"></span> <a href="#" class="challenge-edit"><i class="fa fa-edit"></i></a> <a href="#" class="challenge-delete"><i class="fa fa-minus-circle"></i></a><div class="description"></div><input type="hidden" name="character[character_has_challenges][][id]" value="" /><input type="hidden" name="character[character_has_challenges][][challenge_id]" value="'+id+'" /><input type="hidden" name="character[character_has_challenges][][is_creature_challenge]" value="false" /></li>');
 
   $.ajax({
     url: '/api/challenges/'+id,
@@ -148,9 +149,15 @@ $('#challenges-list').delegate('.challenge-edit', 'click', function(e) {
   var challengeId = $challenge.find('input[name="character[character_has_challenges][][challenge_id]"]').val();
   var name = $challenge.find('input[name="character[character_has_challenges][][custom_name]"]').val();
   var description = $challenge.find('input[name="character[character_has_challenges][][custom_description]"]').val();
+  var creature = $challenge.find('input[name="character[character_has_challenges][][is_creature_challenge]"]').val();
 
   $modal.find('#modal-custom-name').val(name);
   $modal.find('#modal-custom-description').text(description);
+  if (creature == "true") {
+    $modal.find('#modal-creature-challenge').prop("checked", "checked");
+  } else {
+    $modal.find('#modal-creature-challenge').removeProp("checked");
+  }
 
   $modal.find('#modal-chc-id').val(index);
 
@@ -162,6 +169,7 @@ $('#save-challenge').on('click', function(e) {
   var name = $modal.find('#modal-custom-name').val();
   var description = $modal.find('#modal-custom-description').val();
   var challengeToUpdate = $modal.find('#modal-chc-id').val();
+  var creature = $modal.find('#modal-creature-challenge').is(':checked');
   var $challenge = $('#challenges-list li:nth-child('+(parseInt(challengeToUpdate)+1)+')');
   // update both display and hidden field values
 
@@ -169,6 +177,7 @@ $('#save-challenge').on('click', function(e) {
   $challenge.find('input[name="character[character_has_challenges][][custom_name]"]').val(name);
   $challenge.find('.description').html(description);
   $challenge.find('input[name="character[character_has_challenges][][custom_description]"]').val(description);
+  $challenge.find('input[name="character[character_has_challenges][][is_creature_challenge]"]').val(creature);
   $('.overlay').fadeOut();
 });
 

--- a/app/assets/stylesheets/components/_buttons.scss
+++ b/app/assets/stylesheets/components/_buttons.scss
@@ -24,6 +24,10 @@
   }
 }
 
+.button-secondary {
+  transition: .5s;
+}
+
 .button-row {
   display: flex;
   justify-content: flex-start;

--- a/app/controllers/characters_controller.rb
+++ b/app/controllers/characters_controller.rb
@@ -89,12 +89,12 @@ class CharactersController < ApplicationController
 				# add new challenges, and catalog all the challenges that should be on the sheet
 				params[:character][:character_has_challenges].each do |challenge|
 					unless challenge[:id].present?
-						@challenge = CharacterHasChallenge.new(character_id: @character.id, challenge_id: challenge[:challenge_id], custom_name: challenge[:custom_name], custom_description: challenge[:custom_description])
+						@challenge = CharacterHasChallenge.new(character_id: @character.id, challenge_id: challenge[:challenge_id], custom_name: challenge[:custom_name], custom_description: challenge[:custom_description], is_creature_challenge: challenge[:is_creature_challenge])
 						@challenge.save!
 						chc_ids << @challenge.id.to_i
 					else
 						@challenge = CharacterHasChallenge.find(challenge[:id])
-						@challenge.update_attributes!(custom_name: challenge[:custom_name], custom_description: challenge[:custom_description])
+						@challenge.update_attributes!(custom_name: challenge[:custom_name], custom_description: challenge[:custom_description], is_creature_challenge: challenge[:is_creature_challenge])
 						chc_ids << challenge[:id].to_i
 					end
 				end
@@ -175,12 +175,12 @@ class CharactersController < ApplicationController
 				# add new challenges, and catalog all the challenges that should be on the sheet
 				params[:character][:character_has_challenges].each do |challenge|
 					unless challenge[:id].present?
-						@challenge = CharacterHasChallenge.new(character_id: @character.id, challenge_id: challenge[:challenge_id], custom_name: challenge[:custom_name], custom_description: challenge[:custom_description])
+						@challenge = CharacterHasChallenge.new(character_id: @character.id, challenge_id: challenge[:challenge_id], custom_name: challenge[:custom_name], custom_description: challenge[:custom_description], is_creature_challenge: challenge[:is_creature_challenge])
 						@challenge.save!
 						chc_ids << @challenge.id.to_i
 					else
 						@challenge = CharacterHasChallenge.find(challenge[:id])
-						@challenge.update_attributes!(custom_name: challenge[:custom_name], custom_description: challenge[:custom_description])
+						@challenge.update_attributes!(custom_name: challenge[:custom_name], custom_description: challenge[:custom_description], is_creature_challenge: challenge[:is_creature_challenge])
 						chc_ids << challenge[:id].to_i
 					end
 				end

--- a/app/controllers/characters_controller.rb
+++ b/app/controllers/characters_controller.rb
@@ -38,7 +38,8 @@ class CharactersController < ApplicationController
 		@attributes = ATTRIBUTES
 		@skills_training = SKILLS_TRAINING
 		@advantages = Advantage.all
-		@challenges = Challenge.all
+		@challenges = Challenge.where(is_custom: false).order(:name)
+		@custom_challenge = Challenge.where(is_custom: true).first
 		@player = current_user
 		@statuses = STATUS_ENUM
 		@questionnaire_sections = QuestionnaireSection.all.order(order: :asc)
@@ -61,7 +62,8 @@ class CharactersController < ApplicationController
 		@attributes = ATTRIBUTES
 		@skills_training = SKILLS_TRAINING
 		@advantages = Advantage.all
-		@challenges = Challenge.all
+		@challenges = Challenge.where(is_custom: false).order(:name)
+		@custom_challenge = Challenge.where(is_custom: true).first
 		@player = @character.user
 		@questionnaire_sections = QuestionnaireSection.all.order(order: :asc)
 		@statuses = STATUS_ENUM

--- a/app/models/questionnaire_answer.rb
+++ b/app/models/questionnaire_answer.rb
@@ -4,5 +4,4 @@ class QuestionnaireAnswer < ApplicationRecord
 
 	validates :questionnaire_item, presence: true
 	validates :character, 				 presence: true
-	validates :answer, 						 presence: true
 end

--- a/app/views/characters/_form.slim
+++ b/app/views/characters/_form.slim
@@ -65,7 +65,7 @@
     select name="advantages" id="advantages"
       - @advantages.each do |advantage|
         option value="#{advantage.id}" data-allowed-ratings="#{advantage.allowed_ratings}" data-specification="#{advantage.requires_specification}" #{advantage.name} [#{advantage.allowed_ratings}]
-    = button_tag 'Add', type: 'button', class: 'button', id: "advantage-add"
+    = button_tag 'Add', type: 'button', class: 'button-secondary', id: "advantage-add"
 
   ul#advantages-list
     - @character.character_has_advantages.each do |advantage|
@@ -89,13 +89,13 @@
     select name="challenges" id="challenges"
       - @challenges.each do |challenge|
         option value="#{challenge.id}" data-is-custom="#{challenge.is_custom}" #{challenge.name}
-    = button_tag 'Add Creature Challenge', type: 'button', class: 'button', id: "challenge-add"
+    = button_tag 'Add Creature Challenge', type: 'button', class: 'button-secondary', id: "challenge-add"
     - if @custom_challenge.present?
-      = button_tag 'New Challenge', type: 'button', class: 'button', id: 'challenge-add-custom', "data-challenge-id": @custom_challenge.id
+      = button_tag 'New Challenge', type: 'button', class: 'button-secondary', id: 'challenge-add-custom', "data-challenge-id": @custom_challenge.id
 
   ul#challenges-list
     - @character.character_has_challenges.each do |challenge|
-      li
+      li data-creature="#{challenge.is_creature_challenge}"
         - if challenge.challenge.is_custom
           - if challenge.custom_name.present?
             = "<span class='custom-name'>#{challenge.custom_name}</span> ".html_safe
@@ -116,6 +116,7 @@
         = hidden_field_tag "character[character_has_challenges][][challenge_id]", challenge.challenge.id
         = hidden_field_tag "character[character_has_challenges][][custom_name]", challenge.custom_name
         = hidden_field_tag "character[character_has_challenges][][custom_description]", challenge.custom_description
+        = hidden_field_tag "character[character_has_challenges][][is_creature_challenge]", challenge.is_creature_challenge
 
   - if current_user.is_storyteller || @character.status == 3
     h3.section Derived Stats
@@ -199,6 +200,10 @@
         .form-row.description
           = label_tag :custom_description, "Description"
           = text_area_tag :custom_description, "", id: 'modal-custom-description'
+
+        .form-row.creature
+          = check_box_tag :is_creature_challenge, true, false, id: 'modal-creature-challenge'
+          = label_tag :is_creature_challenge, "Is this a creature challenge?"
 
         = hidden_field_tag :chc_id, "", id: 'modal-chc-id'
 

--- a/app/views/characters/_form.slim
+++ b/app/views/characters/_form.slim
@@ -89,7 +89,7 @@
     select name="challenges" id="challenges"
       - @challenges.each do |challenge|
         option value="#{challenge.id}" data-is-custom="#{challenge.is_custom}" #{challenge.name}
-    = button_tag 'Add', type: 'button', class: 'button', id: "challenge-add"
+    = button_tag 'Add Creature Challenge', type: 'button', class: 'button', id: "challenge-add"
     - if @custom_challenge.present?
       = button_tag 'New Challenge', type: 'button', class: 'button', id: 'challenge-add-custom', "data-challenge-id": @custom_challenge.id
 

--- a/app/views/characters/_form.slim
+++ b/app/views/characters/_form.slim
@@ -84,10 +84,13 @@
 
   h3.section Challenges
   .form-row
+    div
+      = label_tag "Creature Challenges"
     select name="challenges" id="challenges"
       - @challenges.each do |challenge|
         option value="#{challenge.id}" data-is-custom="#{challenge.is_custom}" #{challenge.name}
     = button_tag 'Add', type: 'button', class: 'button', id: "challenge-add"
+    = button_tag 'New Challenge', type: 'button', class: 'button', id: 'challenge-add-custom', "data-challenge-id": @custom_challenge.id
 
   ul#challenges-list
     - @character.character_has_challenges.each do |challenge|

--- a/app/views/characters/_form.slim
+++ b/app/views/characters/_form.slim
@@ -90,7 +90,8 @@
       - @challenges.each do |challenge|
         option value="#{challenge.id}" data-is-custom="#{challenge.is_custom}" #{challenge.name}
     = button_tag 'Add', type: 'button', class: 'button', id: "challenge-add"
-    = button_tag 'New Challenge', type: 'button', class: 'button', id: 'challenge-add-custom', "data-challenge-id": @custom_challenge.id
+    - if @custom_challenge.present?
+      = button_tag 'New Challenge', type: 'button', class: 'button', id: 'challenge-add-custom', "data-challenge-id": @custom_challenge.id
 
   ul#challenges-list
     - @character.character_has_challenges.each do |challenge|

--- a/db/migrate/20170128192807_create_challenges.rb
+++ b/db/migrate/20170128192807_create_challenges.rb
@@ -3,8 +3,8 @@ class CreateChallenges < ActiveRecord::Migration[5.0]
     create_table :challenges do |t|
     	t.string :name
     	t.text :description
-    	t.boolean :is_creature_challenge
-      t.boolean :is_custom
+    	t.boolean :is_creature_challenge, default: false
+      t.boolean :is_custom, default: false
       t.timestamps
     end
   end

--- a/db/migrate/20170128205548_create_true_selves.rb
+++ b/db/migrate/20170128205548_create_true_selves.rb
@@ -2,6 +2,7 @@ class CreateTrueSelves < ActiveRecord::Migration[5.0]
   def change
     create_table :true_selves do |t|
       t.string :name, null: false
+      t.text :description
 
       t.timestamps
     end

--- a/db/migrate/201701310636581_create_questionnaire_answers.rb
+++ b/db/migrate/201701310636581_create_questionnaire_answers.rb
@@ -3,7 +3,7 @@ class CreateQuestionnaireAnswers < ActiveRecord::Migration[5.0]
     create_table :questionnaire_answers do |t|
       t.references :questionnaire_item, index: true, foreign_key: true, null: false
       t.references :character,          index: true, foreign_key: true, null: false
-      t.text       :answer,             null: false
+      t.text       :answer,             default: ''
 
       t.timestamps
     end

--- a/db/migrate/201702010636081_create_character_has_challenges.rb
+++ b/db/migrate/201702010636081_create_character_has_challenges.rb
@@ -5,6 +5,7 @@ class CreateCharacterHasChallenges < ActiveRecord::Migration[5.0]
       t.references :challenge, index: true, foreign_key: true, null: false
       t.string :custom_name
       t.text :custom_description
+      t.boolean :is_creature_challenge
 
       t.timestamps
     end

--- a/db/migrate/20170311212541_add_description_for_true_selves.rb
+++ b/db/migrate/20170311212541_add_description_for_true_selves.rb
@@ -1,5 +1,0 @@
-class AddDescriptionForTrueSelves < ActiveRecord::Migration[5.0]
-  def change
-    add_column :true_selves, :description, :text, default: ''
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -110,11 +110,11 @@ ActiveRecord::Schema.define(version: 201702020635481) do
   end
 
   create_table "questionnaire_answers", force: :cascade do |t|
-    t.integer  "questionnaire_item_id", null: false
-    t.integer  "character_id",          null: false
-    t.text     "answer",                null: false
-    t.datetime "created_at",            null: false
-    t.datetime "updated_at",            null: false
+    t.integer  "questionnaire_item_id",              null: false
+    t.integer  "character_id",                       null: false
+    t.text     "answer",                default: ""
+    t.datetime "created_at",                         null: false
+    t.datetime "updated_at",                         null: false
     t.index ["character_id"], name: "index_questionnaire_answers_on_character_id", using: :btree
     t.index ["questionnaire_item_id"], name: "index_questionnaire_answers_on_questionnaire_item_id", using: :btree
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -28,10 +28,10 @@ ActiveRecord::Schema.define(version: 201702020635481) do
   create_table "challenges", force: :cascade do |t|
     t.string   "name"
     t.text     "description"
-    t.boolean  "is_creature_challenge"
-    t.boolean  "is_custom"
-    t.datetime "created_at",            null: false
-    t.datetime "updated_at",            null: false
+    t.boolean  "is_creature_challenge", default: false
+    t.boolean  "is_custom",             default: false
+    t.datetime "created_at",                            null: false
+    t.datetime "updated_at",                            null: false
   end
 
   create_table "character_has_advantages", force: :cascade do |t|
@@ -46,12 +46,13 @@ ActiveRecord::Schema.define(version: 201702020635481) do
   end
 
   create_table "character_has_challenges", force: :cascade do |t|
-    t.integer  "character_id",       null: false
-    t.integer  "challenge_id",       null: false
+    t.integer  "character_id",                          null: false
+    t.integer  "challenge_id",                          null: false
     t.string   "custom_name"
     t.text     "custom_description"
-    t.datetime "created_at",         null: false
-    t.datetime "updated_at",         null: false
+    t.datetime "created_at",                            null: false
+    t.datetime "updated_at",                            null: false
+    t.boolean  "is_creature_challenge", default: false
     t.index ["challenge_id"], name: "index_character_has_challenges_on_challenge_id", using: :btree
     t.index ["character_id"], name: "index_character_has_challenges_on_character_id", using: :btree
   end

--- a/test/models/questionnaire_answer_test.rb
+++ b/test/models/questionnaire_answer_test.rb
@@ -15,9 +15,4 @@ class QuestionnaireAnswerTest < ActiveSupport::TestCase
     test_answer = QuestionnaireAnswer.new(questionnaire_item: questionnaire_items(:one), answer: "an answer")
     assert_not test_answer.valid?
   end
-
-  test "question answers are not valid without an answer" do
-    test_answer = QuestionnaireAnswer.new(questionnaire_item: questionnaire_items(:one), character: characters(:one))
-    assert_not test_answer.valid?
-  end
 end


### PR DESCRIPTION
Closes #35.

Updates to challenge addition: only a short list of challenges should be displayed and available for selection, plus a button that says "New Challenge", which allows for the addition of new personalized challenges. I also added a marker that will allow for checking whether a challenge in the list is a creature challenge or not, and allowed for new challenges to be marked as creature challenges to be able to count for validation purposes.

I also made a few updates to validation for ease of use, also.