### PR TITLE
[57] Restrict editing after character is submitted

### DIFF
--- a/app/controllers/characters_controller.rb
+++ b/app/controllers/characters_controller.rb
@@ -55,6 +55,9 @@ class CharactersController < ApplicationController
 
 	def edit
 		@character = Character.find(params[:id])
+		if (@character.user.id != current_user.id && !current_user.is_storyteller)
+			redirect_to root_path
+		end
 		if @character.status > 0 and !current_user.is_storyteller
 			redirect_to character_path(@character)
 		end
@@ -70,9 +73,6 @@ class CharactersController < ApplicationController
 		end
 		@questionnaire_items = QuestionnaireItem.all.order(order: :asc)
 		@questionnaire_answers = @character.questionnaire_answers
-		if (@character.user.id != current_user.id && !current_user.is_storyteller)
-			redirect_to root_path
-		end
 	end
 
 	def update

--- a/app/views/characters/index.slim
+++ b/app/views/characters/index.slim
@@ -28,7 +28,8 @@
           td
             = character.get_status
           td
-            = link_to "Edit", edit_character_path(character)
+            - unless character.status > 0 and !current_user.is_storyteller
+              = link_to "Edit", edit_character_path(character)
           td
             = form_tag(character_path(character), method: 'DELETE') do
               = button_tag "Delete", type: 'submit', onClick: 'return confirm("Are you sure you want to delete this character?");', class: 'button'


### PR DESCRIPTION
Closes #57.

If a non-storyteller user tries to edit a character sheet that they own but has been submitted, the user will be redirected to the characters#show page. A storyteller attempting to do the same will see the edit page as normal.

Additionally, non-storyteller users will no longer see the edit link next to a character's listing on characters#index after a character has been submitted.