### PR TITLE
[82] Add button-text class and apply to all 'delete' buttons

### DIFF
--- a/app/assets/stylesheets/components/_buttons.scss
+++ b/app/assets/stylesheets/components/_buttons.scss
@@ -56,3 +56,13 @@
     }
   }
 }
+
+.button-text {
+  border: none;
+  padding: 0;
+  font-size: 1em;
+  color: $green;
+  text-decoration: underline;
+  background-color: transparent;
+  cursor: pointer;
+}

--- a/app/views/characters/index.slim
+++ b/app/views/characters/index.slim
@@ -32,4 +32,4 @@
               = link_to "Edit", edit_character_path(character)
           td
             = form_tag(character_path(character), method: 'DELETE') do
-              = button_tag "Delete", type: 'submit', onClick: 'return confirm("Are you sure you want to delete this character?");', class: 'button'
+              = button_tag "Delete", type: 'submit', onClick: 'return confirm("Are you sure you want to delete this character?");', class: 'button-text'

--- a/app/views/storytellers/advantages/index.slim
+++ b/app/views/storytellers/advantages/index.slim
@@ -23,4 +23,4 @@
               = link_to "Edit", edit_storytellers_advantage_path(advantage)
             td
               = form_tag(storytellers_advantage_path(advantage), method: 'DELETE') do
-                = button_tag "Delete", type: 'submit', onClick: 'return confirm("Are you sure you want to delete this advantage?");', class: 'button'
+                = button_tag "Delete", type: 'submit', onClick: 'return confirm("Are you sure you want to delete this advantage?");', class: 'button-text'

--- a/app/views/storytellers/challenges/index.slim
+++ b/app/views/storytellers/challenges/index.slim
@@ -1,7 +1,7 @@
 .data-entry-index
   .breadcrumbs
     = render_breadcrumbs
-    
+
   h2 Challenges
 
   .button-row.right
@@ -23,4 +23,4 @@
               = link_to "Edit", edit_storytellers_challenge_path(challenge)
             td
               = form_tag(storytellers_challenge_path(challenge), method: 'DELETE') do
-                = button_tag "Delete", type: 'submit', onClick: 'return confirm("Are you sure you want to delete this challenge?");', class: 'button'
+                = button_tag "Delete", type: 'submit', onClick: 'return confirm("Are you sure you want to delete this challenge?");', class: 'button-text'

--- a/app/views/storytellers/questionnaire_sections/index.slim
+++ b/app/views/storytellers/questionnaire_sections/index.slim
@@ -30,7 +30,7 @@
                 = link_to "Edit Section & Questions", edit_storytellers_questionnaire_section_path(section)
               td
                 = form_tag(storytellers_questionnaire_section_path(section), method: 'DELETE') do
-                  = button_tag "Delete", type: 'submit', onClick: 'return confirm("Are you sure you want to delete this questionnaire section? This will also delete all the questions in this section.");', class: 'button'
+                  = button_tag "Delete", type: 'submit', onClick: 'return confirm("Are you sure you want to delete this questionnaire section? This will also delete all the questions in this section.");', class: 'button-text'
 
     .button-row
       = submit_tag "Save Ordering", id: 'save-order'

--- a/app/views/storytellers/true_selves/index.slim
+++ b/app/views/storytellers/true_selves/index.slim
@@ -1,7 +1,7 @@
 .data-entry-index
   .breadcrumbs
     = render_breadcrumbs
-    
+
   h2 True Selves
 
   .button-row.right
@@ -23,4 +23,4 @@
               = link_to "Edit", edit_storytellers_true_self_path(true_self)
             td
               = form_tag(storytellers_true_self_path(true_self), method: 'DELETE') do
-                = button_tag "Delete", type: 'submit', onClick: 'return confirm("Are you sure you want to delete this true self?");', class: 'button'
+                = button_tag "Delete", type: 'submit', onClick: 'return confirm("Are you sure you want to delete this true self?");', class: 'button-text'


### PR DESCRIPTION
Closes #82.

Adds the .button-text class, which is styled to look and feel exactly the same as a link, and applied it to all delete buttons across the site.