### PR TITLE
Fix ability to delete characters

### DIFF
--- a/app/controllers/characters_controller.rb
+++ b/app/controllers/characters_controller.rb
@@ -247,7 +247,7 @@ class CharactersController < ApplicationController
 
 	def destroy
 		@character = Character.find(params[:id])
-		@character.delete
+		@character.destroy
 		redirect_to characters_path
 	end
 

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -1,9 +1,9 @@
 class Character < ApplicationRecord
 	belongs_to :user
-	has_many :questionnaire_answers
-	has_many :character_has_challenges
+	has_many :questionnaire_answers, dependent: :destroy
+	has_many :character_has_challenges, dependent: :destroy
 	has_many :challenges, through: :character_has_challenges
-	has_many :character_has_advantages
+	has_many :character_has_advantages, dependent: :destroy
 	has_many :advantages, through: :character_has_advantages
 	belongs_to :true_self
 


### PR DESCRIPTION
Closes #102.
Closes #109.

Needed to make dependent models cascade delete, because apparently Rails makes you do that now.