### PR TITLE
Add output for flash messages

### DIFF
--- a/app/assets/javascripts/common.js
+++ b/app/assets/javascripts/common.js
@@ -22,4 +22,9 @@ $(document).ready(function() {
 
   $('textarea').wrap('<div class="textarea-wrapper"></div>');
   $('.textarea-wrapper').append('<span class="notice">You can use <a href="https://guides.github.com/features/mastering-markdown/" rel="external" target="_blank">Markdown</a> in this area.</span>');
+
+  $('.messages .msg .close a').on('click', function(e) {
+    e.preventDefault();
+    $(this).parents('.msg').fadeOut();
+  });
 });

--- a/app/assets/stylesheets/components/_flash-messages.scss
+++ b/app/assets/stylesheets/components/_flash-messages.scss
@@ -1,0 +1,55 @@
+.messages {
+  margin-top: 5px;
+  .msg {
+    border-width: 1px;
+    border-style: solid;
+    border-radius: 5px;
+    -moz-border-radius: 5px;
+    -webkit-border-radius: 5px;
+    color: $black;
+    padding: 3px 30px 3px 10px;
+    margin-bottom: 5px;
+    position: relative;
+
+    &:last-of-type {
+      margin-bottom: 0;
+    }
+
+    .close {
+      position: absolute;
+      right: 10px;
+      top: 3px;
+
+      a {
+        text-decoration: none;
+      }
+    }
+
+    &.success {
+      background-color: #e8f5e9;
+      border-color: #81c784;
+
+      .close a {
+        color: #81c784;
+      }
+    }
+
+    &.error {
+      background-color: #ffebee;
+      border-color: #e57373;
+
+      .close a {
+        color: #e57373;
+      }
+    }
+
+    &.notice {
+      background-color: #f9fbe7;
+      border-color: #dce775;
+
+      .close a {
+        color: #dce775;
+      }
+    }
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,13 @@
 <body>
   <%= render partial: 'layouts/header' %>
   <div class="main<%= devise_controller? ? ' devise' : '' %>">
+    <% if flash.present? %>
+      <div class="messages">
+        <% flash.each do |type, msg| %>
+          <div class="msg <%= type.to_s %>"><%= msg.html_safe %><a href="#" class="close"><i class="fa fa-times"></i></a></div>
+        <% end %>
+      </div>
+    <% end %>
     <%= yield %>
   </div>
   <%= javascript_include_tag 'footer', 'data-turbolinks-track' => true %>


### PR DESCRIPTION
Closes #104.

The application was using flash messages but not displaying them; this patch outputs the messages to the layout and styles them appropriately based on the type of message (success, error, notice). Messages can be closed by clicking on the "X" on the right-hand side.