### PR TITLE
Remove new character button

### DIFF
--- a/app/views/characters/index.slim
+++ b/app/views/characters/index.slim
@@ -4,7 +4,6 @@
   h2 My Characters
 
 .button-row.right
-  = link_to "New Character", new_character_path, class: 'button new-character-button'
   = link_to "Character Wizard", new_character_wizard_path, class: 'button'
 
 - if @characters.length > 0


### PR DESCRIPTION
Closes #99.

Since we're trying to track people into the wizard instead, removes the new character button.