### PR TITLE
[108] Fix issue w/ is_creature_challenge=nil breaking character form

### DIFF
--- a/app/views/characters/_form.slim
+++ b/app/views/characters/_form.slim
@@ -95,7 +95,7 @@
 
   ul#challenges-list
     - @character.character_has_challenges.each do |challenge|
-      li data-creature="#{challenge.is_creature_challenge}"
+      li data-creature="#{(challenge.is_creature_challenge || challenge.challenge.is_creature_challenge) ? 'true' : 'false'}"
         - if challenge.challenge.is_custom
           - if challenge.custom_name.present?
             = "<span class='custom-name'>#{challenge.custom_name}</span> ".html_safe

--- a/db/migrate/201702010636081_create_character_has_challenges.rb
+++ b/db/migrate/201702010636081_create_character_has_challenges.rb
@@ -5,7 +5,7 @@ class CreateCharacterHasChallenges < ActiveRecord::Migration[5.0]
       t.references :challenge, index: true, foreign_key: true, null: false
       t.string :custom_name
       t.text :custom_description
-      t.boolean :is_creature_challenge
+      t.boolean :is_creature_challenge, default: false
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -46,13 +46,13 @@ ActiveRecord::Schema.define(version: 201702020635481) do
   end
 
   create_table "character_has_challenges", force: :cascade do |t|
-    t.integer  "character_id",          null: false
-    t.integer  "challenge_id",          null: false
+    t.integer  "character_id",                          null: false
+    t.integer  "challenge_id",                          null: false
     t.string   "custom_name"
     t.text     "custom_description"
-    t.boolean  "is_creature_challenge"
-    t.datetime "created_at",            null: false
-    t.datetime "updated_at",            null: false
+    t.boolean  "is_creature_challenge", default: false
+    t.datetime "created_at",                            null: false
+    t.datetime "updated_at",                            null: false
     t.index ["challenge_id"], name: "index_character_has_challenges_on_challenge_id", using: :btree
     t.index ["character_id"], name: "index_character_has_challenges_on_character_id", using: :btree
   end


### PR DESCRIPTION
Closes #108.

As part of trying to set up the ability to count the number of creature challenges present, I was outputting the creature challenge status of each challenge in data attributes. However, when set to nil, it was not able to print correctly.

This will require running rake db:reset to add the default of false to a field.