### PR TITLE
add proper formatting for logout button on mobile

### DIFF
--- a/app/assets/stylesheets/components/_header.scss
+++ b/app/assets/stylesheets/components/_header.scss
@@ -161,7 +161,7 @@ header {
 
         > li {
           margin: 0;
-          > a, > span {
+          > a, > span, > form {
             height: auto;
             line-height: 1.2;
             display: block;


### PR DESCRIPTION
Logout button looked a little too different in the mobile menu from the rest of the links because it's a form and not a span or an a, so I added the correct formatting.