### PR TITLE
[117] Hide status for submitted characters except for storytellers

### DIFF
--- a/app/views/characters/index.slim
+++ b/app/views/characters/index.slim
@@ -25,7 +25,8 @@
             td
               = character.user.name
           td
-            = character.get_status
+            - if character.status == 0 or current_user.is_storyteller
+              = character.get_status
           td
             - unless character.status > 0 and !current_user.is_storyteller
               = link_to "Edit", edit_character_path(character)


### PR DESCRIPTION
Closes #117.

Hides character status after character is submitted, unless the current user is a storyteller. This means we can move a character to "Active" without the player potentially being notified immediately.