### PR TITLE
[116] Add button to edit in character wizard

### DIFF
--- a/app/views/characters/_form.slim
+++ b/app/views/characters/_form.slim
@@ -1,4 +1,7 @@
 .character
+  .button-row.right
+    = link_to "Edit in Wizard", @character.id.present? ? character_wizard_path(@character) : new_character_wizard_path, class: 'button'
+
   .form-row.basic-stats
     .stat.name
       = f.label :name

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
   get 'characters/wizard', to: 'characters#wizard', as: 'new_character_wizard'
   get 'characters/print_all', to: 'characters#print_all', as: 'characters_print'
   resources :characters
-  get 'characters/:id/wizard', to: 'characters#wizard'
+  get 'characters/:id/wizard', to: 'characters#wizard', as: 'character_wizard'
   get 'characters/:id/wizard/basics', to: 'characters#wizard_basics'
   get 'characters/:id/wizard/skills_trainings', to: 'characters#wizard_skills_trainings'
   get 'characters/:id/wizard/challenges_advantages', to: 'characters#wizard_challenges_advantages'


### PR DESCRIPTION
Closes #116.

Adds button that allows user to return to the character wizard to edit their character instead of viewing the full sheet.