### PR TITLE
[118] Link 'my characters' to root_path, adjust mobile styling

### DIFF
--- a/app/assets/stylesheets/components/_header.scss
+++ b/app/assets/stylesheets/components/_header.scss
@@ -166,7 +166,7 @@ header {
             line-height: 1.2;
             display: block;
             padding: 10px 20px;
-            border-bottom: 1px rgba($black, .2);
+            border-bottom: 1px rgba($black, .5);
 
             &:after {
               bottom: 0;
@@ -183,7 +183,8 @@ header {
             box-shadow: none;
             border-bottom: 1px rgba($black, .25) solid;
             transform: translate(0);
-            display: none;
+            display: block;
+            opacity: 1;
           }
 
           &:hover {

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -4,7 +4,7 @@
     <nav>
       <ul>
         <% if current_user %>
-          <li class="parent"><span>My Characters</span>
+          <li class="parent"><%= link_to "My Characters", root_path %>
             <ul class="sub-menu">
                 <% current_user.characters.each do |character| %>
                   <li><%= link_to character.name, character_path(character) %></li>


### PR DESCRIPTION
Closes #118.

Links "My Characters" to root_path, and adjusts mobile styling such that submenu is always open so that there's no issue with needing to double click stuff.