### PR TITLE
[139] prevent buttons from getting squished on small screens

### DIFF
--- a/app/assets/stylesheets/components/_buttons.scss
+++ b/app/assets/stylesheets/components/_buttons.scss
@@ -50,12 +50,14 @@
 .button-row {
   display: flex;
   justify-content: flex-start;
+  flex-wrap: wrap;
   margin: 20px 0;
   width: 100%;
 
   .button, input[type="submit"] {
     margin-right: 20px;
     margin-left: 0;
+    flex-shrink: 0;
   }
 
   &.right {


### PR DESCRIPTION
Closes #139.

adds flex-wrap: wrap to .button-rows and flex-shrink: 0 to buttons and inputs in those rows.