### PR TITLE
[161] Show message after reg indicating user should look for confirmation email

### DIFF
--- a/app/assets/javascripts/common.js
+++ b/app/assets/javascripts/common.js
@@ -8,7 +8,7 @@ $(document).ready(function() {
     }
   });
 
-  $('.messages .msg .close a').on('click', function(e) {
+  $('.messages .msg .close').on('click', function(e) {
     e.preventDefault();
     $(this).parents('.msg').fadeOut();
   });

--- a/app/assets/stylesheets/components/_flash-messages.scss
+++ b/app/assets/stylesheets/components/_flash-messages.scss
@@ -41,11 +41,11 @@
     }
 
     &.notice, &.alert {
-      background-color: #f9fbe7;
-      border-color: #827717;
+      background-color: #f5f5f5;
+      border-color: #9e9e9e;
 
       .close {
-        color: #827717;
+        color: #9e9e9e;
       }
     }
   }

--- a/app/assets/stylesheets/components/_flash-messages.scss
+++ b/app/assets/stylesheets/components/_flash-messages.scss
@@ -24,10 +24,10 @@
 
     &.success {
       background-color: #e8f5e9;
-      border-color: #827717;
+      border-color: #81c784;
 
       .close {
-        color: #827717;
+        color: #81c784;
       }
     }
 
@@ -42,10 +42,10 @@
 
     &.notice, &.alert {
       background-color: #f9fbe7;
-      border-color: #dce775;
+      border-color: #827717;
 
       .close {
-        color: #dce775;
+        color: #827717;
       }
     }
   }

--- a/app/assets/stylesheets/components/_flash-messages.scss
+++ b/app/assets/stylesheets/components/_flash-messages.scss
@@ -19,18 +19,15 @@
       position: absolute;
       right: 10px;
       top: 3px;
-
-      a {
-        text-decoration: none;
-      }
+      text-decoration: none;
     }
 
     &.success {
       background-color: #e8f5e9;
-      border-color: #81c784;
+      border-color: #827717;
 
-      .close a {
-        color: #81c784;
+      .close {
+        color: #827717;
       }
     }
 
@@ -38,16 +35,16 @@
       background-color: #ffebee;
       border-color: #e57373;
 
-      .close a {
+      .close {
         color: #e57373;
       }
     }
 
-    &.notice {
+    &.notice, &.alert {
       background-color: #f9fbe7;
       border-color: #dce775;
 
-      .close a {
+      .close {
         color: #dce775;
       }
     }

--- a/app/assets/stylesheets/pages/devise.scss
+++ b/app/assets/stylesheets/pages/devise.scss
@@ -2,6 +2,12 @@
   max-width: none;
   background-image: url('/assets/misty-woods.jpg');
   background-size: cover;
+
+  .messages {
+    max-width: $large-media-query-size;
+    margin: 5px auto;
+    width: 100%;
+  }
 }
 
 .devise-page {

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -3,5 +3,6 @@ class RegistrationsController < Devise::RegistrationsController
 
   def after_inactive_sign_up_path_for(resource)
     flash[:alert] = I18n.t 'devise.confirmations.send_instructions'
+    redirect_to new_user_session_path and return
   end
 end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,13 +1,8 @@
 class RegistrationsController < Devise::RegistrationsController
   protected
 
-  def after_sign_up_path_for(resource)
-    flash[:alert] = i18n.t('en.devise.confirmations.send_instructions')
-    redirect_to new_user_session_path
-  end
-
   def after_inactive_sign_up_path_for(resource)
-    flash[:alert] = i18n.t('en.devise.confirmations.send_instructions')
+    flash[:alert] = I18n.t 'devise.confirmations.send_instructions'
     redirect_to new_user_session_path
   end
 end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,0 +1,8 @@
+class RegistrationsController < Devise::RegistrationsController
+  protected
+
+  def after_sign_up_path_for(resource)
+    flash[:alert] = i18n.t('en.devise.confirmations.send_instructions')
+    redirect_to new_user_session_path
+  end
+end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -5,4 +5,9 @@ class RegistrationsController < Devise::RegistrationsController
     flash[:alert] = i18n.t('en.devise.confirmations.send_instructions')
     redirect_to new_user_session_path
   end
+
+  def after_inactive_sign_up_path_for(resource)
+    flash[:alert] = i18n.t('en.devise.confirmations.send_instructions')
+    redirect_to new_user_session_path
+  end
 end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -2,7 +2,9 @@ class RegistrationsController < Devise::RegistrationsController
   protected
 
   def after_inactive_sign_up_path_for(resource)
-    flash[:alert] = I18n.t 'devise.confirmations.send_instructions'
-    redirect_to new_user_session_path and return
+    scope = Devise::Mapping.find_scope!(resource)
+    router_name = Devise.mappings[scope].router_name
+    context = router_name ? send(router_name) : self
+    context.respond_to?(:new_user_session_path) ? context.new_user_session_path : "/users/sign_in"
   end
 end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -3,6 +3,6 @@ class RegistrationsController < Devise::RegistrationsController
 
   def after_inactive_sign_up_path_for(resource)
     flash[:alert] = I18n.t 'devise.confirmations.send_instructions'
-    redirect_to new_user_session_path
+    redirect_to new_user_session_path and return
   end
 end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -3,6 +3,5 @@ class RegistrationsController < Devise::RegistrationsController
 
   def after_inactive_sign_up_path_for(resource)
     flash[:alert] = I18n.t 'devise.confirmations.send_instructions'
-    redirect_to new_user_session_path and return
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -10,7 +10,7 @@ Rails.application.configure do
   config.eager_load = false
 
   # Full error reports are disabled and caching is turned on.
-  config.consider_all_requests_local       = false
+  config.consider_all_requests_local       = true
 
   config.cache_classes = false
   config.action_controller.perform_caching = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -10,7 +10,7 @@ Rails.application.configure do
   config.eager_load = false
 
   # Full error reports are disabled and caching is turned on.
-  config.consider_all_requests_local       = true
+  config.consider_all_requests_local       = false
 
   config.cache_classes = false
   config.action_controller.perform_caching = false

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  devise_for :users
+  devise_for :users, controllers: { registrations: "registrations" }
 
   root to: 'characters#index'
 


### PR DESCRIPTION
Closes #161.

Adds a post-registration action that redirects the user to the login page and indicates that they should look for a confirmation email. Also tweaks message styling a little bit. (NOW COMPLETE pls R&R)