### PR TITLE
[162] Implement mechanics sheets for players

### DIFF
--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -25,4 +25,12 @@ h2 {
   .qualitative {
     page-break-before: always;
   }
+
+  .column-content {
+    columns: 2;
+
+    .column-item {
+      break-inside: avoid;
+    }
+  }
 }

--- a/app/controllers/characters_controller.rb
+++ b/app/controllers/characters_controller.rb
@@ -357,6 +357,18 @@ class CharactersController < ApplicationController
 		render layout: 'print'
 	end
 
+	def print_all_mechanics
+		unless current_user.is_storyteller
+			redirect_to root_path and return
+		end
+		@characters = Character.where({status: 2}).order(:name)
+
+		renderer = Redcarpet::Render::HTML.new(no_links: true, hard_wrap: true, filter_html: true)
+		@markdown = Redcarpet::Markdown.new(renderer, extensions = {})
+		render layout: 'print'
+	end
+
+
 	def send_approvals
 		unless current_user.is_storyteller
 			redirect_to root_path and return

--- a/app/views/characters/print_all_mechanics.slim
+++ b/app/views/characters/print_all_mechanics.slim
@@ -1,0 +1,42 @@
+- if @characters
+  - @characters.each do |character|
+    .sheet.mechanics-sheet
+      h2 #{character.name}: Mechanics
+
+      .mechanics-content
+        h3 Basics
+
+        p Add a cheat sheet here that contains a basic mechanics refresher, kind of like the stuff we've put on the back cover of the DCP rulebook some years.
+
+        h3 True Self
+        = raw @markdown.render(character.true_self.description)
+
+        - if character.challenges.present?
+          h3 Challenges
+          .column-content
+            - character.character_has_challenges.each do |challenge|
+              .column-item
+                p
+                  strong #{challenge.custom_name.present? ? challenge.custom_name : challenge.challenge.name}
+                .challenge-description
+                  - if challenge.custom_description.present?
+                    = raw @markdown.render(challenge.custom_description)
+                  - else
+                    = raw @markdown.render(challenge.challenge.description)
+
+        h3 Advantages
+
+        .column-content
+          - character.character_has_advantages.group_by{|adv| adv.advantage_id}.each do |k, group|
+            - group.each_with_index do |cha, i|
+              .column-item
+                p
+                  strong
+                    = cha.advantage.name
+                    - if cha.advantage.requires_specification?
+                      = " (#{cha.specification})"
+                    - if cha.advantage.allowed_ratings.length > 1
+                      = " #{cha.rating}"
+                - if i == group.length-1
+                  .advantage-description
+                    = raw @markdown.render(cha.advantage.description)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   root to: 'characters#index'
 
   get 'characters/wizard', to: 'characters#wizard', as: 'new_character_wizard'
+  get 'characters/print_all_mechanics', to: 'characters#print_all_mechanics', as: 'characters_print_mechanics'
   get 'characters/print_all', to: 'characters#print_all', as: 'characters_print'
   resources :characters
   get 'characters/:id/wizard', to: 'characters#wizard', as: 'character_wizard'

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -51,9 +51,9 @@ ActiveRecord::Schema.define(version: 201702020635481) do
     t.integer  "challenge_id",                          null: false
     t.string   "custom_name"
     t.text     "custom_description"
+    t.boolean  "is_creature_challenge", default: false
     t.datetime "created_at",                            null: false
     t.datetime "updated_at",                            null: false
-    t.boolean  "is_creature_challenge", default: false
     t.index ["challenge_id"], name: "index_character_has_challenges_on_challenge_id", using: :btree
     t.index ["character_id"], name: "index_character_has_challenges_on_character_id", using: :btree
   end
@@ -112,6 +112,31 @@ ActiveRecord::Schema.define(version: 201702020635481) do
     t.index ["user_id"], name: "index_characters_on_user_id", using: :btree
   end
 
+  create_table "downtime_actions", force: :cascade do |t|
+    t.string   "title",                              null: false
+    t.string   "assets"
+    t.boolean  "burn",               default: false
+    t.text     "description",                        null: false
+    t.boolean  "is_submitted",       default: false
+    t.text     "response"
+    t.integer  "downtime_period_id",                 null: false
+    t.integer  "character_id",                       null: false
+    t.datetime "created_at",                         null: false
+    t.datetime "updated_at",                         null: false
+    t.integer  "size",               default: 0
+    t.integer  "status",             default: 0
+    t.integer  "action_type",        default: 0,     null: false
+  end
+
+  create_table "downtime_periods", force: :cascade do |t|
+    t.string   "title"
+    t.boolean  "downtimes_visible"
+    t.datetime "created_at",                        null: false
+    t.datetime "updated_at",                        null: false
+    t.boolean  "downtimes_open",    default: false
+    t.boolean  "is_active",         default: false
+  end
+
   create_table "questionnaire_answers", force: :cascade do |t|
     t.integer  "questionnaire_item_id",              null: false
     t.integer  "character_id",                       null: false
@@ -141,10 +166,10 @@ ActiveRecord::Schema.define(version: 201702020635481) do
   end
 
   create_table "true_selves", force: :cascade do |t|
-    t.string   "name",                     null: false
-    t.datetime "created_at",               null: false
-    t.datetime "updated_at",               null: false
-    t.text     "description", default: ""
+    t.string   "name",        null: false
+    t.text     "description"
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
Closes #162.

See /characters/print_all_mechanics when logged in as storyteller. Only shows active characters, so make sure at least one character has the "active" status.

Probably needs one last thing—for the mechanics sheets, we talked about having a brief primer for all players on there that goes over the basics; we need someone to write that up still. (Someone from the mechanics squad?) We might be able to borrow some of it or at least the format from the cheat sheet that DCP has printed in rulebooks in the past.