### PR TITLE
[163] hide validation counters if character is active

### DIFF
--- a/app/views/characters/_form.slim
+++ b/app/views/characters/_form.slim
@@ -28,7 +28,8 @@
       .column
         strong
           = cat
-          span.counter.hidden id="#{cat.to_s.parameterize}-count"
+          - if @character.status < 2
+            span.counter.hidden id="#{cat.to_s.parameterize}-count"
         - vals.each do |val|
           .row
             label
@@ -44,14 +45,15 @@
 
   h3.section
     | Skills and Special Training
-    span.counter#skills-total 22 Remaining
+    - if @character.status < 2
+      span.counter#skills-total 22 Remaining
 
   .flex-container.skills-training
     - @skills_training.each do |cat,vals|
       div class="column #{cat.to_s.parameterize}"
         strong
           = cat
-          - if cat.to_s == "Special Training"
+          - if cat.to_s == "Special Training" and @character.status < 2
             span.counter#special-training 8 Remaining
         - vals.each do |val|
           .row
@@ -70,7 +72,8 @@
 
   h3.section
     | Advantages
-    span.counter#advantage-count 17 Remaining
+    - if @character.status < 2
+      span.counter#advantage-count 17 Remaining
   .form-row
     select name="advantages" id="advantages"
       - @advantages.each do |advantage|
@@ -94,9 +97,10 @@
 
   h3.section
     | Challenges
-    .counters
-      span.counter#challenge-count 2 Remaining
-      span.counter#creature-challenge-count 1 Creature Challenge Remaining
+    - if @character.status < 2
+      .counters
+        span.counter#challenge-count 2 Remaining
+        span.counter#creature-challenge-count 1 Creature Challenge Remaining
   .form-row
     div
       = label_tag "Creature Challenges"

--- a/app/views/characters/wizard_basics.slim
+++ b/app/views/characters/wizard_basics.slim
@@ -27,7 +27,8 @@
           .column
             strong
               = cat
-              span.counter.hidden id="#{cat.to_s.parameterize}-count"
+              - if @character.status < 2
+                span.counter.hidden id="#{cat.to_s.parameterize}-count"
             - vals.each do |val|
               .row
                 label

--- a/app/views/characters/wizard_challenges_advantages.slim
+++ b/app/views/characters/wizard_challenges_advantages.slim
@@ -7,7 +7,8 @@
 
     h3.section
       | Advantages
-      span.counter#advantage-count 17 Remaining
+      - if @character.status < 2
+        span.counter#advantage-count 17 Remaining
 
     div
       select name="advantages" id="advantages"
@@ -34,9 +35,10 @@
 
     h3.section
       | Challenges
-      .counters
-        span.counter#challenge-count 2 Remaining
-        span.counter#creature-challenge-count 1 Creature Challenge Remaining
+      - if @character.status < 2
+        .counters
+          span.counter#challenge-count 2 Remaining
+          span.counter#creature-challenge-count 1 Creature Challenge Remaining
 
     div
       = label_tag "Creature Challenges"

--- a/app/views/characters/wizard_skills_trainings.slim
+++ b/app/views/characters/wizard_skills_trainings.slim
@@ -7,14 +7,15 @@
 
     h3.section
       | Skills and Special Training
-      span.counter#skills-total 22 Remaining
+      - if @character.status < 2
+        span.counter#skills-total 22 Remaining
 
     .flex-container.skills-training
       - @skills_training.each do |cat,vals|
         div class="column #{cat.to_s.parameterize}"
           strong
             = cat
-            - if cat.to_s == "Special Training"
+            - if cat.to_s == "Special Training" and @character.status < 2
               span.counter#special-training 8 Remaining
           - vals.each do |val|
             .row
@@ -32,7 +33,7 @@
                       = f.radio_button val.parameterize("_").to_sym, i, label: false
 
     p.instructions Each character has both #{link_to("Skills and Special Trainings", "http://askagainlater.com/rules/skills-special-training/", rel: 'external', target: '_blank')}, and they have 22 points to split between the two categories. Each rank in a Skill or Special Training costs 1 point, and both traits can only be raised to a maximum of 5 per individual Skill or Special Training. In addition, a character can only spend up to 8 of their 22 points on Special Trainings but they are not required to spend any on Special Trainings.
-    
+
     = hidden_field_tag "wizard_current", "skills_trainings"
     = hidden_field_tag "wizard_prev", "basics"
     = hidden_field_tag "wizard", "challenges_advantages"


### PR DESCRIPTION
Closes #163.

Basically just hides the places where the validation updates the text if @character.status >= 2 (for active/inactive characters). Should still validate for in progress and submitted characters.