### PR TITLE
[66] Advancement System

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,8 @@ gem 'breadcrumbs_on_rails'
 
 gem 'postmark-rails', '~> 0.15.0'
 
+gem 'activerecord-diff'
+
 # Use Unicorn as the app server
 # gem 'unicorn'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,6 +33,7 @@ GEM
       activemodel (= 5.0.1)
       activesupport (= 5.0.1)
       arel (~> 7.0)
+    activerecord-diff (2.0.0)
     activesupport (5.0.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (~> 0.7)
@@ -205,6 +206,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activerecord-diff
   angularjs-rails (~> 1.6, >= 1.6.1)
   bcrypt (~> 3.1.7)
   breadcrumbs_on_rails

--- a/app/assets/javascripts/characters.js
+++ b/app/assets/javascripts/characters.js
@@ -203,7 +203,7 @@ $(document).ready(function() {
   function updateAdvantageCount() {
     var count = 0;
     var $indicator = $('#advantage-count');
-    var $advantages = $('#advantages-list input[name="character[character_has_advantages][][rating]"]');
+    var $advantages = $('#advantages-list li:visible input[name="character[character_has_advantages_attributes][][rating]"]');
     $advantages.each(function() {
       count += parseInt($(this).val());
     });
@@ -217,7 +217,7 @@ $(document).ready(function() {
   updateAdvantageCount();
 
   function updateChallengeCount() {
-    var count = $('#challenges-list li').length;
+    var count = $('#challenges-list li:visible').length;
     var $indicator = $('#challenge-count');
     $indicator.text((2-count)+" Remaining");
     if (count > 2) {
@@ -230,7 +230,7 @@ $(document).ready(function() {
   updateChallengeCount();
 
   function updateCreatureChallengeCount() {
-    var count = $('#challenges-list li[data-creature="true"]').length;
+    var count = $('#challenges-list li[data-creature="true"]:visible').length;
     var $indicator = $('#creature-challenge-count');
     $indicator.text((1-count)+" Creature Challenges Remaining");
     if (count > 1) {
@@ -255,7 +255,7 @@ $(document).ready(function() {
     } else {
       lowestRating = ratings;
     }
-    $('ul#advantages-list').append('<li>'+name+((specification) ? ' (<span class="specification"></span>)' : '')+((ratings.length > 1) ? ' <span class="rating">'+lowestRating+'</span>' : '')+' <a href="#" class="advantage-edit"><i class="fa fa-edit"></i></a> <a href="#" class="advantage-delete"><i class="fa fa-minus-circle"></i></a><input type="hidden" name="character[character_has_advantages][][id]" value="" /><input type="hidden" name="character[character_has_advantages][][advantage_id]" value="'+advantageId+'" /><input type="hidden" name="character[character_has_advantages][][rating]" value="'+lowestRating+'" /><input type="hidden" name="character[character_has_advantages][][specification]" value="" /></li>');
+    $('ul#advantages-list').append('<li>'+name+((specification) ? ' (<span class="specification"></span>)' : '')+((ratings.length > 1) ? ' <span class="rating">'+lowestRating+'</span>' : '')+' <a href="#" class="advantage-edit"><i class="fa fa-edit"></i></a> <a href="#" class="advantage-delete"><i class="fa fa-minus-circle"></i></a><input type="hidden" name="character[character_has_advantages_attributes][][id]" value="" /><input type="hidden" name="character[character_has_advantages_attributes][][advantage_id]" value="'+advantageId+'" /><input type="hidden" name="character[character_has_advantages_attributes][][rating]" value="'+lowestRating+'" /><input type="hidden" name="character[character_has_advantages_attributes][][specification]" value="" /></li>');
     updateAdvantageCount();
   });
 
@@ -265,9 +265,9 @@ $(document).ready(function() {
     var $modal = $('#advantages-overlay .modal');
     var $advantage = $(this).parent('li');
     var index = $advantage.index();
-    var rating = $advantage.find('input[name="character[character_has_advantages][][rating]"]').val();
-    var advantageId = $advantage.find('input[name="character[character_has_advantages][][advantage_id]"]').val();
-    var specification = $advantage.find('input[name="character[character_has_advantages][][specification]"]').val();
+    var rating = $advantage.find('input[name="character[character_has_advantages_attributes][][rating]"]').val();
+    var advantageId = $advantage.find('input[name="character[character_has_advantages_attributes][][advantage_id]"]').val();
+    var specification = $advantage.find('input[name="character[character_has_advantages_attributes][][specification]"]').val();
     // get advantage data from API
 
     $.ajax({
@@ -318,9 +318,9 @@ $(document).ready(function() {
     // update both display and hidden field values
 
     $advantage.find('.rating').text(rating);
-    $advantage.find('input[name="character[character_has_advantages][][rating]"]').val(rating);
+    $advantage.find('input[name="character[character_has_advantages_attributes][][rating]"]').val(rating);
     $advantage.find('.specification').text(specification);
-    $advantage.find('input[name="character[character_has_advantages][][specification]"]').val(specification);
+    $advantage.find('input[name="character[character_has_advantages_attributes][][specification]"]').val(specification);
     $('.overlay').fadeOut();
     updateAdvantageCount();
   });
@@ -331,7 +331,8 @@ $(document).ready(function() {
 
   $('#advantages-list').delegate(".advantage-delete", 'click', function(e) {
     e.preventDefault();
-    $(this).parent('li').detach();
+    $(this).parent('li').hide();
+    $(this).parent('li').find('input[name="character[character_has_advantages_attributes][][_destroy]"]').val(1);
     updateAdvantageCount();
   });
 
@@ -341,7 +342,7 @@ $(document).ready(function() {
     var name = $selected.text();
     var challengeId = $selected.val();
 
-    $('ul#challenges-list').append('<li data-challenge-id="'+challengeId+'" data-creature="true"><span class="custom-name">'+name+'</span> <a href="#" class="challenge-delete"><i class="fa fa-minus-circle"></i></a><div class="description"></div><input type="hidden" name="character[character_has_challenges][][id]" value="" /><input type="hidden" name="character[character_has_challenges][][challenge_id]" value="'+challengeId+'" /><input type="hidden" name="character[character_has_challenges][][custom_description]" value="" /><input type="hidden" name="character[character_has_challenges][][custom_name]" value="" /><input type="hidden" name="character[character_has_challenges][][is_creature_challenge]" value="true" /></li>');
+    $('ul#challenges-list').append('<li data-challenge-id="'+challengeId+'" data-creature="true"><span class="custom-name">'+name+'</span> <a href="#" class="challenge-delete"><i class="fa fa-minus-circle"></i></a><div class="description"></div><input type="hidden" name="character[character_has_challenges_attributes][][id]" value="" /><input type="hidden" name="character[character_has_challenges_attributes][][challenge_id]" value="'+challengeId+'" /><input type="hidden" name="character[character_has_challenges_attributes][][custom_description]" value="" /><input type="hidden" name="character[character_has_challenges_attributes][][custom_name]" value="" /><input type="hidden" name="character[character_has_challenges_attributes][][is_creature_challenge]" value="true" /></li>');
 
     $.ajax({
       url: '/api/challenges/'+challengeId,
@@ -360,7 +361,7 @@ $(document).ready(function() {
     e.preventDefault();
     var id = $(this).data('challenge-id');
 
-    $('ul#challenges-list').append('<li data-challenge-id="'+id+'"><span class="custom-name"></span> <a href="#" class="challenge-edit"><i class="fa fa-edit"></i></a> <a href="#" class="challenge-delete"><i class="fa fa-minus-circle"></i></a><div class="description"></div><input type="hidden" name="character[character_has_challenges][][id]" value="" /><input type="hidden" name="character[character_has_challenges][][challenge_id]" value="'+id+'" /><input type="hidden" name="character[character_has_challenges][][custom_name]" value="" /><input type="hidden" name="character[character_has_challenges][][custom_description]" value="" /><input type="hidden" name="character[character_has_challenges][][is_creature_challenge]" value="false" /></li>');
+    $('ul#challenges-list').append('<li data-challenge-id="'+id+'"><span class="custom-name"></span> <a href="#" class="challenge-edit"><i class="fa fa-edit"></i></a> <a href="#" class="challenge-delete"><i class="fa fa-minus-circle"></i></a><div class="description"></div><input type="hidden" name="character[character_has_challenges_attributes][][id]" value="" /><input type="hidden" name="character[character_has_challenges_attributes][][challenge_id]" value="'+id+'" /><input type="hidden" name="character[character_has_challenges_attributes][][custom_name]" value="" /><input type="hidden" name="character[character_has_challenges_attributes][][custom_description]" value="" /><input type="hidden" name="character[character_has_challenges_attributes][][is_creature_challenge]" value="false" /></li>');
 
     $.ajax({
       url: '/api/challenges/'+id,
@@ -380,10 +381,10 @@ $(document).ready(function() {
     var $modal = $('#challenges-overlay .modal');
     var $challenge = $(this).parent('li');
     var index = $challenge.index();
-    var challengeId = $challenge.find('input[name="character[character_has_challenges][][challenge_id]"]').val();
-    var name = $challenge.find('input[name="character[character_has_challenges][][custom_name]"]').val();
-    var description = $challenge.find('input[name="character[character_has_challenges][][custom_description]"]').val();
-    var creature = $challenge.find('input[name="character[character_has_challenges][][is_creature_challenge]"]').val();
+    var challengeId = $challenge.find('input[name="character[character_has_challenges_attributes][][challenge_id]"]').val();
+    var name = $challenge.find('input[name="character[character_has_challenges_attributes][][custom_name]"]').val();
+    var description = $challenge.find('input[name="character[character_has_challenges_attributes][][custom_description]"]').val();
+    var creature = $challenge.find('input[name="character[character_has_challenges_attributes][][is_creature_challenge]"]').val();
 
     $modal.find('#modal-custom-name').val(name);
     $modal.find('#modal-custom-description').text(description);
@@ -408,10 +409,10 @@ $(document).ready(function() {
     var converter = new showdown.Converter();
 
     $challenge.find('.custom-name').text(name);
-    $challenge.find('input[name="character[character_has_challenges][][custom_name]"]').val(name);
+    $challenge.find('input[name="character[character_has_challenges_attributes][][custom_name]"]').val(name);
     $challenge.find('.description').html(converter.makeHtml(description));
-    $challenge.find('input[name="character[character_has_challenges][][custom_description]"]').val(description);
-    $challenge.find('input[name="character[character_has_challenges][][is_creature_challenge]"]').val(creature);
+    $challenge.find('input[name="character[character_has_challenges_attributes][][custom_description]"]').val(description);
+    $challenge.find('input[name="character[character_has_challenges_attributes][][is_creature_challenge]"]').val(creature);
     $challenge.attr('data-creature', creature);
     $('.overlay').fadeOut();
     updateChallengeCount();
@@ -424,8 +425,10 @@ $(document).ready(function() {
 
   $('#challenges-list').delegate('.challenge-delete', 'click', function(e) {
     e.preventDefault();
-    $(this).parent('li').detach();
+    $(this).parent('li').hide();
+    $(this).parent('li').find('input[name="character[character_has_challenges_attributes][][_destroy]"]').val(1);
     updateChallengeCount();
+    updateCreatureChallengeCount();
   });
 
   $('.dot').on('click', function() {

--- a/app/assets/stylesheets/components/_datatables.scss
+++ b/app/assets/stylesheets/components/_datatables.scss
@@ -15,3 +15,25 @@ table.dataTable {
     }
   }
 }
+
+table.plain {
+  margin: 20px 0;
+  th, td {
+    padding: 3px 5px;
+  }
+  thead {
+    th {
+      font-weight: bold;
+      text-align: left;
+    }
+    border-bottom: 1px $green solid;
+  }
+
+  tbody {
+    tr {
+      &:nth-child(2n+2) {
+        background-color: rgba($silver, .25);
+      }
+    }
+  }
+}

--- a/app/controllers/characters_controller.rb
+++ b/app/controllers/characters_controller.rb
@@ -88,15 +88,8 @@ class CharactersController < ApplicationController
 			@character.status = 1
 		end
 		if @character.status == 2 and !current_user.is_storyteller
-			params[:character][:character_has_challenges_attributes].each do |chc|
-				chc.delete(:id)
-			end
-			params[:character][:character_has_advantages_attributes].each do |cha|
-				cha.delete(:id)
-			end
-			params[:character][:questionnaire_answers_attributes].each do |qa|
-				qa.delete(:id)
-			end
+			params[:character][:id] = @character.id
+			puts characters_params.inspect
 			@character_updated = Character.new(characters_params)
 			diff = @character.diff(@character_updated)
 			@expenditure = XpExpenditure.new(character_id: @character.id, diff: diff.to_json)
@@ -284,6 +277,6 @@ class CharactersController < ApplicationController
 	protected
 
 	def characters_params
-		params.require(:character).permit(:name, :user_id, :status, :true_self_id, :stability, :handy, :religion, :bureaucracy, :athletics, :fight, :drive, :guns, :theft, :stealth, :outdoorsy, :empathy, :artsy, :intimidation, :persuasion, :lies, :academics, :investigation, :medicine, :local_lore, :law, :science, :computers, :engineering, :public_blurb, :willpower, :defense, :speed, :intelligence, :wits, :resolve, :strength, :dexterity, :stamina, :presence, :manipulation, :composure, :speed, :initiative, :willpower, :health, :defense, :pronouns, :use_extended, :character_has_advantages_attributes => [:id, :advantage_id, :character_id, :specification, :rating, :_destroy], :character_has_challenges_attributes => [:id, :character_id, :challenge_id, :custom_name, :custom_description, :is_creature_challenge, :_destroy], :questionnaire_answers_attributes => [:id, :questionnaire_item_id, :answer, :character_id])
+		params.require(:character).permit(:id, :name, :user_id, :status, :true_self_id, :stability, :handy, :religion, :bureaucracy, :athletics, :fight, :drive, :guns, :theft, :stealth, :outdoorsy, :empathy, :artsy, :intimidation, :persuasion, :lies, :academics, :investigation, :medicine, :local_lore, :law, :science, :computers, :engineering, :public_blurb, :willpower, :defense, :speed, :intelligence, :wits, :resolve, :strength, :dexterity, :stamina, :presence, :manipulation, :composure, :speed, :initiative, :willpower, :health, :defense, :pronouns, :use_extended, :character_has_advantages_attributes => [:id, :advantage_id, :character_id, :specification, :rating, :_destroy], :character_has_challenges_attributes => [:id, :character_id, :challenge_id, :custom_name, :custom_description, :is_creature_challenge, :_destroy], :questionnaire_answers_attributes => [:id, :questionnaire_item_id, :answer, :character_id])
 	end
 end

--- a/app/controllers/characters_controller.rb
+++ b/app/controllers/characters_controller.rb
@@ -92,6 +92,10 @@ class CharactersController < ApplicationController
 			diff = @character.diff(@character_updated)
 			@expenditure = XpExpenditure.new(character_id: @character.id, diff: diff.to_json)
 			@expenditure.save
+			@storytellers = User.where(is_storyteller: true)
+			@storytellers.each do |st|
+				CharacterMailer.character_experience_expenditure(@character, @expenditure, st).deliver_now
+			end
 			flash[:success] = "Experience expenditure for #{@character.name} submitted."
 			redirect_to character_path(@character) and return
 		end

--- a/app/controllers/characters_controller.rb
+++ b/app/controllers/characters_controller.rb
@@ -92,6 +92,7 @@ class CharactersController < ApplicationController
 			diff = @character.diff(@character_updated)
 			@expenditure = XpExpenditure.new(character_id: @character.id, diff: diff.to_json)
 			@expenditure.save
+			flash[:success] = "Experience expenditure for #{@character.name} submitted."
 			redirect_to character_path(@character) and return
 		end
 		if @character.update_attributes!(characters_params)

--- a/app/controllers/characters_controller.rb
+++ b/app/controllers/characters_controller.rb
@@ -83,13 +83,11 @@ class CharactersController < ApplicationController
 	def update
 		@character = Character.find(params[:id])
 		oldstatus = @character.status
-		puts params[:character].inspect
 		if params[:submit].present? && params[:submit]
 			@character.status = 1
 		end
 		if @character.status == 2 and !current_user.is_storyteller
 			params[:character][:id] = @character.id
-			puts characters_params.inspect
 			@character_updated = Character.new(characters_params)
 			diff = @character.diff(@character_updated)
 			@expenditure = XpExpenditure.new(character_id: @character.id, diff: diff.to_json)

--- a/app/controllers/characters_controller.rb
+++ b/app/controllers/characters_controller.rb
@@ -88,6 +88,15 @@ class CharactersController < ApplicationController
 			@character.status = 1
 		end
 		if @character.status == 2 and !current_user.is_storyteller
+			params[:character][:character_has_challenges_attributes].each do |chc|
+				chc.delete(:id)
+			end
+			params[:character][:character_has_advantages_attributes].each do |cha|
+				cha.delete(:id)
+			end
+			params[:character][:questionnaire_answers_attributes].each do |qa|
+				qa.delete(:id)
+			end
 			@character_updated = Character.new(characters_params)
 			diff = @character.diff(@character_updated)
 			@expenditure = XpExpenditure.new(character_id: @character.id, diff: diff.to_json)

--- a/app/controllers/characters_controller.rb
+++ b/app/controllers/characters_controller.rb
@@ -59,7 +59,7 @@ class CharactersController < ApplicationController
 		if (@character.user.id != current_user.id && !current_user.is_storyteller)
 			redirect_to root_path and return
 		end
-		if @character.status > 0 and !current_user.is_storyteller
+		if @character.status > 0 and !current_user.is_storyteller and @character.current_xp <= 0
 			redirect_to character_path(@character) and return
 		end
 		@attributes = ATTRIBUTES
@@ -85,6 +85,13 @@ class CharactersController < ApplicationController
 		oldstatus = @character.status
 		if params[:submit].present? && params[:submit]
 			@character.status = 1
+		end
+		if @character.status == 2 and !current_user.is_storyteller
+			@character_updated = Character.new(characters_params)
+			diff = @character.diff(@character_updated)
+			@expenditure = XpExpenditure.new(character_id: @character.id, diff: diff.to_json)
+			@expenditure.save
+			redirect_to character_path(@character) and return
 		end
 		if @character.update_attributes!(characters_params)
 			flash[:success] = "Changes to your character were saved."

--- a/app/controllers/characters_controller.rb
+++ b/app/controllers/characters_controller.rb
@@ -246,6 +246,15 @@ class CharactersController < ApplicationController
 		end
 	end
 
+	def delete_expenditure
+		@character = Character.find(params[:id])
+		unless current_user == @character.user or current_user.is_storyteller
+			redirect_to root_path and return
+		end
+		XpExpenditure.destroy(params[:expenditure_id])
+		redirect_to character_path(@character) and return
+	end
+
 	def print_all
 		unless current_user.is_storyteller
 			redirect_to root_path and return

--- a/app/controllers/storytellers/experience_controller.rb
+++ b/app/controllers/storytellers/experience_controller.rb
@@ -74,6 +74,16 @@ module Storytellers
       redirect_to storytellers_experience_path and return
     end
 
+    def destroy
+      XpRecord.destroy(params[:id])
+      redirect_to storytellers_experience_path and return
+    end
+
+    def destroy_expenditure
+      XpExpenditure.destroy(params[:id])
+      redirect_to storytellers_experience_path and return
+    end
+
     private
 
     def xp_record_params

--- a/app/controllers/storytellers/experience_controller.rb
+++ b/app/controllers/storytellers/experience_controller.rb
@@ -75,6 +75,7 @@ module Storytellers
         end
       end
       @character.save
+      CharacterMailer.character_expenditure_approved(@character, @xpe).deliver_now
       @xpe.update_attributes(is_approved: true)
       @xpr = XpRecord.new(character_id: @character.id, amount: @xpe.amount*-1, description: log.join(", "))
       @xpr.save

--- a/app/controllers/storytellers/experience_controller.rb
+++ b/app/controllers/storytellers/experience_controller.rb
@@ -31,6 +31,11 @@ module Storytellers
       add_breadcrumb "Experience Expenditure for #{@xpe.character.name}", storytellers_show_experience_expenditure_path
     end
 
+    def mass
+      add_breadcrumb "Experience", storytellers_experience_path
+      add_breadcrumb "Add Experience to Active Characters", storytellers_mass_assign_experience_path
+    end
+
     def mass_assign
       @characters = Character.where(status: 2, is_npc: false)
       @characters.each do |char|

--- a/app/controllers/storytellers/experience_controller.rb
+++ b/app/controllers/storytellers/experience_controller.rb
@@ -18,7 +18,7 @@ module Storytellers
     end
 
     def create
-      @character = Character.find(params[:character_id])
+      @character = Character.find(params[:xp_record][:character_id])
       @xpr = XpRecord.new(xp_record_params)
       @xpr.save
       redirect_to storytellers_experience_path and return

--- a/app/controllers/storytellers/experience_controller.rb
+++ b/app/controllers/storytellers/experience_controller.rb
@@ -21,6 +21,7 @@ module Storytellers
       @character = Character.find(params[:xp_record][:character_id])
       @xpr = XpRecord.new(xp_record_params)
       @xpr.save
+      flash[:success] = "#{params[:xp_record][:amount]} experience added to #{@character.name}."
       redirect_to storytellers_experience_path and return
     end
 
@@ -42,6 +43,7 @@ module Storytellers
         @xpr = XpRecord.new(character_id: char.id, amount: params[:amount], description: params[:description])
         @xpr.save
       end
+      flash[:success] = "#{params[:amount]} experience added to all active characters."
       redirect_to storytellers_experience_path and return
     end
 
@@ -76,6 +78,7 @@ module Storytellers
       @xpe.update_attributes(is_approved: true)
       @xpr = XpRecord.new(character_id: @character.id, amount: @xpe.amount*-1, description: log.join(", "))
       @xpr.save
+      flash[:success] = "Experience expenditure for #{@character.name} approved."
       redirect_to storytellers_experience_path and return
     end
 

--- a/app/controllers/storytellers/experience_controller.rb
+++ b/app/controllers/storytellers/experience_controller.rb
@@ -1,0 +1,83 @@
+module Storytellers
+  class ExperienceController < ApplicationController
+    before_action :authenticate_user!, :requires_storyteller
+
+    add_breadcrumb "Storytellers", :storytellers_path
+
+    def index
+      @expenditures = XpExpenditure.where(is_approved: false)
+      @records = XpRecord.all.order(created_at: :desc)
+
+      add_breadcrumb "Experience", storytellers_experience_path
+    end
+
+    def new
+      @xpr = XpRecord.new
+      add_breadcrumb "Experience", storytellers_experience_path
+      add_breadcrumb "Add Experience to Character", storytellers_new_experience_record_path
+    end
+
+    def create
+      @character = Character.find(params[:character_id])
+      @xpr = XpRecord.new(xp_record_params)
+      @xpr.save
+      redirect_to storytellers_experience_path and return
+    end
+
+    def show
+      @xpe = XpExpenditure.find(params[:id])
+
+      add_breadcrumb "Experience", storytellers_experience_path
+      add_breadcrumb "Experience Expenditure for #{@xpe.character.name}", storytellers_show_experience_expenditure_path
+    end
+
+    def mass_assign
+      @characters = Character.where(status: 2, is_npc: false)
+      @characters.each do |char|
+        @xpr = XpRecord.new(character_id: char.id, amount: params[:amount], description: params[:description])
+        @xpr.save
+      end
+      redirect_to storytellers_experience_path and return
+    end
+
+    def approve_expenditure
+      @xpe = XpExpenditure.find(params[:id])
+      @character = @xpe.character
+      diff = @xpe.diff
+      log = []
+      JSON.parse(@xpe.diff).each do |item, val|
+        if item != "character_has_advantages" and item != "character_has_challenges"
+          @character.send("#{item}=", val[1])
+          log.push("#{item.titleize} #{val[1]}")
+        elsif item == "character_has_advantages"
+          advantages_old = val[0]
+          advantages_new = val[1]
+          advantages_removed = advantages_old.select{|ao| advantages_new.index{|an| an['id'] == ao['id']}.nil?}
+          advantages_updated = advantages_new.select{|an| ab = advantages_old.bsearch{|ao| an['id'] == ao['id']}; ab.present? ? ab['rating'] != an['rating'] : false}
+          advantages_added = advantages_new.select{|an| an['id'].nil?}
+          advantages_removed.each{|ar| CharacterHasAdvantage.destroy(ar['id'])}
+          advantages_updated.each{|au| @character.character_has_advantages.where(id: au['id']).first.rating = au['rating']}
+          advantages_added.each{|aa| @character.character_has_advantages.push(CharacterHasAdvantage.new(advantage_id: aa['advantage_id'], rating: aa['rating'], specification: aa['specification']))}
+        elsif item == "character_has_challenges"
+          challenges_old = val[0]
+          challenges_new = val[1]
+          challenges_added = challenges_new.select{|cn| cn['id'].nil?}
+          challenges_removed = challenges_old.select{|co| challenges_new.index{|cn| cn['id'] == co['id']}.nil?}
+          challenges_removed.each{|cr| CharacterHasChallenge.destroy(cr['id'])}
+          challenges_added.each{|ca| @character.character_has_challenges.push(CharacterHasChallenge.new(challenge_id: ca['challenge_id'], custom_name: ca['custom_name'], custom_description: ca['custom_description']))}
+        end
+      end
+      @character.save
+      @xpe.update_attributes(is_approved: true)
+      @xpr = XpRecord.new(character_id: @character.id, amount: @xpe.amount*-1, description: log.join(", "))
+      @xpr.save
+      redirect_to storytellers_experience_path and return
+    end
+
+    private
+
+    def xp_record_params
+      params.require(:xp_record).permit(:id, :character_id, :amount, :description)
+    end
+  end
+end

--- a/app/mailers/character_mailer.rb
+++ b/app/mailers/character_mailer.rb
@@ -17,4 +17,25 @@ class CharacterMailer < ActionMailer::Base
 			:to => @user.email,
 			:from => 'sts@askagainlater.com')
 	end
+
+	def character_experience_expenditure(character, expenditure, st)
+		@character = character
+		@expenditure = expenditure
+		@st_name = st.name
+		mail(
+			:subject => "[AAL Character System] New experience expenditure for #{@character.name}",
+			:to => st.email,
+			:from => 'sts@askagainlater.com'
+		)
+	end
+
+	def character_expenditure_approved(character, expenditure)
+		@character = character
+		@expenditure = expenditure
+		mail(
+			:subject => "[AAL Character System] Experience expenditure for #{@character.name} approved",
+			:to => @character.user.email,
+			:from => 'sts@askagainlater.com'
+		)
+	end
 end

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -2,7 +2,7 @@ require 'active_record/diff'
 
 class Character < ApplicationRecord
 	include ActiveRecord::Diff
-	diff :include => [:character_has_advantages, :character_has_challenges]
+	diff :include => [:character_has_advantages, :character_has_challenges], :exclude => [:created_at, :updated_at, :speed, :willpower, :health, :defense, :stability, :status, :initiative]
 	belongs_to :user
 	has_many :questionnaire_answers, dependent: :destroy
 	has_many :character_has_challenges, dependent: :destroy

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -1,4 +1,7 @@
+require 'active_record/diff'
+
 class Character < ApplicationRecord
+	include ActiveRecord::Diff
 	belongs_to :user
 	has_many :questionnaire_answers, dependent: :destroy
 	has_many :character_has_challenges, dependent: :destroy
@@ -16,6 +19,15 @@ class Character < ApplicationRecord
 
 	def get_status
 		return STATUS[self.status]
+	end
+
+	def current_xp
+		xprecords = XpRecord.where(character_id: self.id)
+		total = 0;
+		xprecords.each do |xpr|
+			total += xpr.amount
+		end
+		total
 	end
 
 	private

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -11,7 +11,9 @@ class Character < ApplicationRecord
 	has_many :downtime_actions
 	belongs_to :true_self
 
-	accepts_nested_attributes_for :questionnaire_answers, :character_has_challenges, :character_has_advantages
+	accepts_nested_attributes_for :questionnaire_answers
+	accepts_nested_attributes_for :character_has_challenges, allow_destroy: true
+	accepts_nested_attributes_for :character_has_advantages, allow_destroy: true
 
 	validates :user, presence: true
 

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -2,6 +2,7 @@ require 'active_record/diff'
 
 class Character < ApplicationRecord
 	include ActiveRecord::Diff
+	diff :include => [:character_has_advantages, :character_has_challenges]
 	belongs_to :user
 	has_many :questionnaire_answers, dependent: :destroy
 	has_many :character_has_challenges, dependent: :destroy

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -10,6 +10,8 @@ class Character < ApplicationRecord
 	has_many :character_has_advantages, dependent: :destroy
 	has_many :advantages, through: :character_has_advantages
 	has_many :downtime_actions
+	has_many :xp_records
+	has_many :xp_expenditures
 	belongs_to :true_self
 
 	accepts_nested_attributes_for :questionnaire_answers

--- a/app/models/character_has_advantage.rb
+++ b/app/models/character_has_advantage.rb
@@ -1,4 +1,10 @@
+require 'active_record/diff'
+
 class CharacterHasAdvantage < ApplicationRecord
+	include ActiveRecord::Diff
+
+	diff :exclude => [:created_at, :updated_at, :character_id, :advantage_id]
+	
 	belongs_to :advantage
 	belongs_to :character
 end

--- a/app/models/character_has_challenge.rb
+++ b/app/models/character_has_challenge.rb
@@ -1,4 +1,9 @@
+require 'active_record/diff'
+
 class CharacterHasChallenge < ApplicationRecord
+	include ActiveRecord::Diff
+	diff :exclude => [:created_at, :updated_at, :character_id, :challenge_id]
+
 	belongs_to :character
 	belongs_to :challenge
 end

--- a/app/models/xp_expenditure.rb
+++ b/app/models/xp_expenditure.rb
@@ -35,30 +35,32 @@ class XpExpenditure < ApplicationRecord
 			end
 		end
 
-		advantages_old = diff['character_has_advantages'][0]
-		advantages_new = diff['character_has_advantages'][1]
+		if diff['character_has_advantages'].present?
+			advantages_old = diff['character_has_advantages'][0]
+			advantages_new = diff['character_has_advantages'][1]
 
-		advantages_removed = advantages_old.select{|ao| advantages_new.index{|an| an['id'] == ao['id']}.nil?}
-		advantages_updated = advantages_old.reject{|ao| ab = advantages_new.bsearch{|an| an['id'] == ao['id']}; ab.present? ? ab['rating'] == ao['rating'] : true}
-		advantages_added = advantages_new.select{|an| an['id'].nil?}
+			advantages_removed = advantages_old.select{|ao| advantages_new.index{|an| an['id'] == ao['id']}.nil?}
+			advantages_updated = advantages_old.reject{|ao| ab = advantages_new.bsearch{|an| an['id'] == ao['id']}; ab.present? ? ab['rating'] == ao['rating'] : true}
+			advantages_added = advantages_new.select{|an| an['id'].nil?}
 
-		advantages_updated.each do |au|
-			oldval = advantages_old.bsearch{|ao| ao['id'] == au['id']}
-			newval = advantages_new.bsearch{|an| an['id'] == au['id']}
-			if oldval.nil?
-				diffval = newval['rating']
-			else
-				diffval = newval['rating'] - oldval['rating']
+			advantages_updated.each do |au|
+				oldval = advantages_old.bsearch{|ao| ao['id'] == au['id']}
+				newval = advantages_new.bsearch{|an| an['id'] == au['id']}
+				if oldval.nil?
+					diffval = newval['rating']
+				else
+					diffval = newval['rating'] - oldval['rating']
+				end
+				count += diffval
 			end
-			count += diffval
-		end
 
-		advantages_removed.each do |ar|
-			count -= ar['rating']
-		end
+			advantages_removed.each do |ar|
+				count -= ar['rating']
+			end
 
-		advantages_added.each do |aa|
-			count += aa['rating']
+			advantages_added.each do |aa|
+				count += aa['rating']
+			end
 		end
 
 		self.amount = count

--- a/app/models/xp_expenditure.rb
+++ b/app/models/xp_expenditure.rb
@@ -1,0 +1,40 @@
+class XpExpenditure < ApplicationRecord
+	belongs_to :character
+
+	validates :character, presence: true
+	validates :amount,    presence: true
+
+  before_save :calc_amount
+
+  private
+
+  def calc_amount
+    diff = JSON.parse(self.diff)
+		count = 0
+		attributes = ['intelligence', 'wits', 'resolve', 'strength', 'dexterity', 'stamina', 'presence', 'manipuation', 'composure']
+		skills = ['artsy', 'athletics', 'bureaucracy', 'drive', 'empathy', 'fight', 'guns', 'handy', 'intimidation', 'lies', 'outdoorsy', 'persuasion', 'religion', 'stealth', 'theft']
+		training = ['academics', 'computers', 'engineering', 'investigation', 'law', 'local_lore', 'medicine', 'science']
+		attributes.each do |at|
+			unless diff[at].nil?
+				minus = diff[at][1] - diff[at][0]
+				count += minus*4
+			end
+		end
+
+		skills.each do |sk|
+			unless diff[sk].nil?
+				minus = diff[sk][1] - diff[sk][0]
+				count += minus*1
+			end
+		end
+
+		training.each do |tr|
+			unless diff[tr].nil?
+				minus = diff[tr][1] - diff[tr][0]
+				count += minus*2
+			end
+		end
+
+		self.amount = count
+  end
+end

--- a/app/models/xp_expenditure.rb
+++ b/app/models/xp_expenditure.rb
@@ -35,6 +35,32 @@ class XpExpenditure < ApplicationRecord
 			end
 		end
 
+		advantages_old = diff['character_has_advantages'][0]
+		advantages_new = diff['character_has_advantages'][1]
+
+		advantages_removed = advantages_old.select{|ao| advantages_new.index{|an| an['id'] == ao['id']}.nil?}
+		advantages_updated = advantages_old.reject{|ao| ab = advantages_new.bsearch{|an| an['id'] == ao['id']}; ab.present? ? ab['rating'] == ao['rating'] : true}
+		advantages_added = advantages_new.select{|an| an['id'].nil?}
+
+		advantages_updated.each do |au|
+			oldval = advantages_old.bsearch{|ao| ao['id'] == au['id']}
+			newval = advantages_new.bsearch{|an| an['id'] == au['id']}
+			if oldval.nil?
+				diffval = newval['rating']
+			else
+				diffval = newval['rating'] - oldval['rating']
+			end
+			count += diffval
+		end
+
+		advantages_removed.each do |ar|
+			count -= ar['rating']
+		end
+
+		advantages_added.each do |aa|
+			count += aa['rating']
+		end
+
 		self.amount = count
   end
 end

--- a/app/views/character_mailer/character_expenditure_approved.html.erb
+++ b/app/views/character_mailer/character_expenditure_approved.html.erb
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <style type="text/css">
+    body {
+      text-align: center;
+      margin: 50px auto;
+      background-color: #aebfaf;
+      font-size: 16px;
+      font-family: "Lucida Grande", Arial, sans-serif;
+    }
+
+    a {
+      color: #5C7A6A;
+    }
+
+    table {
+      margin: 0 auto;
+    }
+
+    .content-header {
+      height: 60px;
+      text-align: left;
+      padding: 0 30px;
+    }
+
+    h1 {
+      font-size: 36px;
+      line-height: 36px;
+      color: #FFFFFF;
+      font-family: "Palatino", "Georgia", "Times New Roman", serif;
+      margin: 0;
+    }
+
+    h1 a {
+      color: #FFFFFF;
+      text-decoration: none;
+      font-weight: normal;
+    }
+
+    h2 {
+      font-family: "Palatino", "Georgia", "Times New Roman", serif;
+      margin-top: 0;
+    }
+
+    .content-body {
+      padding: 30px;
+      text-align: left;
+    }
+  </style>
+  <body>
+    <table cellpadding="0" cellspacing="0" border="0" width="600">
+      <tr>
+        <td bgcolor="#333333" color="#FFFFFF" class="content-header" height="60" valign="middle">
+          <h1><a href="<%= root_url %>">AAL Character System</a></h1>
+        </td>
+      </tr>
+      <tr>
+        <td bgcolor="#FFFFFF" color="#333333" class="content-body">
+          <h2>Experience Expenditure for <%= @character.name %> Approved</h2>
+          <p>Hi, <%= @character.user.name %>!</p>
+          <p>Your experience expenditure for <%= @character.name %> has been approved. To view your updated sheet, <a href="<%= root_url %>characters/<%= @character.id %>">click here</a>.</p>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/app/views/character_mailer/character_expenditure_approved.txt.erb
+++ b/app/views/character_mailer/character_expenditure_approved.txt.erb
@@ -1,0 +1,5 @@
+Experience Expenditure for <%= @character.name %> Approved
+
+Hi, <%= @character.user.name %>!
+
+Your experience expenditure for <%= @character.name %> has been approved. To view your updated sheet, click here: <%= root_url %>characters/<%= @character.id %>

--- a/app/views/character_mailer/character_experience_expenditure.html.erb
+++ b/app/views/character_mailer/character_experience_expenditure.html.erb
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <style type="text/css">
+    body {
+      text-align: center;
+      margin: 50px auto;
+      background-color: #aebfaf;
+      font-size: 16px;
+      font-family: "Lucida Grande", Arial, sans-serif;
+    }
+
+    a {
+      color: #5C7A6A;
+    }
+
+    table {
+      margin: 0 auto;
+    }
+
+    .content-header {
+      height: 60px;
+      text-align: left;
+      padding: 0 30px;
+    }
+
+    h1 {
+      font-size: 36px;
+      line-height: 36px;
+      color: #FFFFFF;
+      font-family: "Palatino", "Georgia", "Times New Roman", serif;
+      margin: 0;
+    }
+
+    h1 a {
+      color: #FFFFFF;
+      text-decoration: none;
+      font-weight: normal;
+    }
+
+    h2 {
+      font-family: "Palatino", "Georgia", "Times New Roman", serif;
+      margin-top: 0;
+    }
+
+    .content-body {
+      padding: 30px;
+      text-align: left;
+    }
+  </style>
+  <body>
+    <table cellpadding="0" cellspacing="0" border="0" width="600">
+      <tr>
+        <td bgcolor="#333333" color="#FFFFFF" class="content-header" height="60" valign="middle">
+          <h1><a href="<%= root_url %>">AAL Character System</a></h1>
+        </td>
+      </tr>
+      <tr>
+        <td bgcolor="#FFFFFF" color="#333333" class="content-body">
+          <h2>New Experience Expenditure for <%= @character.name %></h2>
+          <p>Hi, <%= @st_name %>!</p>
+          <p><%= @character.user.name %> has submitted an experience expenditure for <%= @character.name %>. To review it, <a href="<%= root_url %>storytellers/experience/<%= @expenditure.id %>">click here</a>.</p>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/app/views/character_mailer/character_experience_expenditure.txt.erb
+++ b/app/views/character_mailer/character_experience_expenditure.txt.erb
@@ -1,0 +1,5 @@
+New Experience Expenditure for <%= @character.name %>
+
+Hi, <%= @st_name %>!
+
+<%= @character.user.name %> has submitted an experience expenditure for <%= @character.name %>. To review it, click here: <%= root_url %>storytellers/experience/<%= @expenditure.id %>

--- a/app/views/characters/_form.slim
+++ b/app/views/characters/_form.slim
@@ -84,11 +84,12 @@
         - if advantage.advantage.requires_specification
           = "(<span class='specification'>#{advantage.specification}</span>) ".html_safe
         - if advantage.advantage.allowed_ratings.split(",").length > 1
-          = " <span class='rating'>#{advantage.rating}</span>".html_safe
-        = hidden_field_tag "character[character_has_advantages][][id]", advantage.id
-        = hidden_field_tag "character[character_has_advantages][][advantage_id]", advantage.advantage.id
-        = hidden_field_tag "character[character_has_advantages][][rating]", advantage.rating
-        = hidden_field_tag "character[character_has_advantages][][specification]", advantage.specification
+          = " <span class='rating'>#{advantage.rating}</span> ".html_safe
+        = hidden_field_tag "character[character_has_advantages_attributes][][id]", advantage.id
+        = hidden_field_tag "character[character_has_advantages_attributes][][advantage_id]", advantage.advantage.id
+        = hidden_field_tag "character[character_has_advantages_attributes][][rating]", advantage.rating
+        = hidden_field_tag "character[character_has_advantages_attributes][][specification]", advantage.specification
+        = hidden_field_tag "character[character_has_advantages_attributes][][_destroy]", ""
         = link_to "<i class='fa fa-edit'></i>".html_safe, "#", class: 'advantage-edit'
         = link_to "<i class='fa fa-minus-circle'></i>".html_safe, "#", class: 'advantage-delete'
 
@@ -127,11 +128,12 @@
         - elsif challenge.challenge.description.present?
           .description
             = raw @markdown.render(challenge.challenge.description)
-        = hidden_field_tag "character[character_has_challenges][][id]", challenge.id
-        = hidden_field_tag "character[character_has_challenges][][challenge_id]", challenge.challenge.id
-        = hidden_field_tag "character[character_has_challenges][][custom_name]", challenge.custom_name
-        = hidden_field_tag "character[character_has_challenges][][custom_description]", challenge.custom_description
-        = hidden_field_tag "character[character_has_challenges][][is_creature_challenge]", challenge.is_creature_challenge
+        = hidden_field_tag "character[character_has_challenges_attributes][][id]", challenge.id
+        = hidden_field_tag "character[character_has_challenges_attributes][][challenge_id]", challenge.challenge.id
+        = hidden_field_tag "character[character_has_challenges_attributes][][custom_name]", challenge.custom_name
+        = hidden_field_tag "character[character_has_challenges_attributes][][custom_description]", challenge.custom_description
+        = hidden_field_tag "character[character_has_challenges_attributes][][is_creature_challenge]", challenge.is_creature_challenge
+        = hidden_field_tag "character[character_has_challenges_attributes][][_destroy]", ""
 
   - if current_user.is_storyteller || @character.status == 3
     h3.section Derived Stats
@@ -169,12 +171,12 @@
                   = question.question
                 - if @questionnaire_answers.where(questionnaire_item_id: question.id).length > 0
                   - current_question = @questionnaire_answers.where(questionnaire_item_id: question.id).first
-                  = text_area_tag "character[questionnaire_answers][][answer]", current_question.answer
-                  = hidden_field_tag "character[questionnaire_answers][][id]", current_question.id
+                  = text_area_tag "character[questionnaire_answers_attributes][][answer]", current_question.answer
+                  = hidden_field_tag "character[questionnaire_answers_attributes][][id]", current_question.id
                 - else
-                  = text_area_tag "character[questionnaire_answers][][answer]"
-                  = hidden_field_tag "character[questionnaire_answers][][id]"
-                = hidden_field_tag "character[questionnaire_answers][][questionnaire_item_id]", question.id
+                  = text_area_tag "character[questionnaire_answers_attributes][][answer]"
+                  = hidden_field_tag "character[questionnaire_answers_attributes][][id]"
+                = hidden_field_tag "character[questionnaire_answers_attributes][][questionnaire_item_id]", question.id
 
   .button-row
     = f.submit "Save"

--- a/app/views/characters/index.slim
+++ b/app/views/characters/index.slim
@@ -33,6 +33,8 @@
           td
             - unless character.status > 0 and !current_user.is_storyteller
               = link_to "Edit", edit_character_path(character)
+            - if character.status > 1 and !current_user.is_storyteller and character.current_xp > 0
+              = link_to "Spend Experience", edit_character_path(character)
           td
             = form_tag(character_path(character), method: 'DELETE') do
               = button_tag "Delete", type: 'submit', onClick: 'return confirm("Are you sure you want to delete this character?");', class: 'button-text'

--- a/app/views/characters/show.slim
+++ b/app/views/characters/show.slim
@@ -132,4 +132,91 @@
                 - if @character.questionnaire_answers.where(questionnaire_item_id: qi.id).present?
                   = raw @markdown.render(@character.questionnaire_answers.where(questionnaire_item_id: qi.id).first.answer)
 
+  h3.section Experience
+
+  table
+    thead
+      tr
+        th Date
+        th Amount
+        th Description
+    tbody
+      - if character.xp_records.present?
+        - character.xp_records.each do |xpr|
+          tr
+            td #{xpr.created_at}
+            td #{xpr.amount}
+            td #{xpr.description}
+
+  h4 Pending Expenditures
+
+  .expenditure
+    - if character.xp_expenditures.present?
+      - character.xp_expenditures.each do |xpe|
+        - JSON.parse(xpe.diff).each do |item, val|
+          - if item != "character_has_advantages" and item != "character_has_challenges"
+            li
+              strong #{item.titleize}
+              = " from "
+              em #{val[0]}
+              = " to "
+              em #{val[1]}
+          - elsif item == "character_has_advantages"
+            - advantages_old = val[0]
+            - advantages_new = val[1]
+            - advantages_removed = advantages_old.select{|ao| advantages_new.index{|an| an['id'] == ao['id']}.nil?}
+            - advantages_updated = advantages_old.reject{|ao| ab = advantages_new.bsearch{|an| an['id'] == ao['id']}; ab.present? ? ab['rating'] == ao['rating'] : true}
+            - advantages_added = advantages_new.select{|an| an['id'].nil?}
+            - unless advantages_removed.empty?
+              - advantages_removed.each do |ar|
+                - advantage = CharacterHasAdvantage.find(ar['id'])
+                li
+                  = "Removed "
+                  strong #{advantage.advantage.name}#{advantage.specification.present? ? " #{advantage.specification}" : ''} #{advantage.rating}
+            - unless advantages_updated.empty?
+              - advantages_updated.each do |au|
+                - advantage = CharacterHasAdvantage.find(au['id'])
+                li
+                  strong #{advantage.advantage.name}#{advantage.specification.present? ? " (#{advantage.specification})" : ''}
+                  = " from "
+                  em #{advantage.rating}
+                  = " to "
+                  em #{au['rating']}
+            - unless advantages_added.empty?
+              - advantages_added.each do |aa|
+                - advantage = Advantage.find(aa['advantage_id'])
+                li
+                  strong #{advantage.name}#{aa['specification'].present? ? " (#{aa['specification']})" : ''}
+                  = " from "
+                  em 0
+                  = " to "
+                  em #{aa['rating']}
+          - elsif item == "character_has_challenges"
+            - challenges_old = val[0]
+            - challenges_new = val[1]
+            - challenges_added = challenges_new.select{|cn| cn['id'].nil?}
+            - challenges_removed = challenges_old.select{|co| challenges_new.index{|cn| cn['id'] == co['id']}.nil?}
+            - unless challenges_removed.empty?
+              - challenges_removed.each do |cr|
+                - challenge = CharacterHasChallenge.find(cr['id'])
+            - unless challenges_added.empty?
+              - challenges_added.each do |ca|
+                - challenge = Challenge.find(ca['challenge_id'])
+                li
+                  = "Adding Challenge "
+                  - if ca['custom_name'].present?
+                    strong #{ca['custom_name']}
+                  - else
+                    strong #{challenge.name}
+                  - if ca['custom_description'].present?
+                    .description
+                      = raw @markdown.render(ca['custom_description'])
+    p.total
+      strong Total Points Spent:
+      = " #{xpe.amount}"
+    .button-row
+      = form_tag(character_delete_xp_expenditure_path(@character, xpe), method: 'DELETE')
+        = submit_tag
+
+
   = javascript_include_tag 'characters', 'data-turbolinks-track' => true

--- a/app/views/characters/show.slim
+++ b/app/views/characters/show.slim
@@ -134,15 +134,15 @@
 
   h3.section Experience
 
-  table
+  table.plain
     thead
       tr
         th Date
         th Amount
         th Description
     tbody
-      - if character.xp_records.present?
-        - character.xp_records.each do |xpr|
+      - if @character.xp_records.present?
+        - @character.xp_records.each do |xpr|
           tr
             td #{xpr.created_at}
             td #{xpr.amount}
@@ -151,8 +151,8 @@
   h4 Pending Expenditures
 
   .expenditure
-    - if character.xp_expenditures.present?
-      - character.xp_expenditures.each do |xpe|
+    - if @character.xp_expenditures.where(is_approved: false).present?
+      - @character.xp_expenditures.where(is_approved: false).each do |xpe|
         - JSON.parse(xpe.diff).each do |item, val|
           - if item != "character_has_advantages" and item != "character_has_challenges"
             li
@@ -211,12 +211,12 @@
                   - if ca['custom_description'].present?
                     .description
                       = raw @markdown.render(ca['custom_description'])
-    p.total
-      strong Total Points Spent:
-      = " #{xpe.amount}"
-    .button-row
-      = form_tag(character_delete_xp_expenditure_path(@character, xpe), method: 'DELETE')
-        = submit_tag
+        p.total
+          strong Total Points Spent:
+          = " #{xpe.amount}"
+        .button-row
+          = form_tag(character_delete_xp_expenditure_path(@character, xpe), method: 'DELETE')
+            = button_tag "Cancel Expenditure", type: 'submit', class: 'button-text'
 
 
   = javascript_include_tag 'characters', 'data-turbolinks-track' => true

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -16,6 +16,7 @@
             <li class="parent"><%= link_to "Tools", storytellers_path %>
               <ul class="sub-menu">
                 <li><%= link_to "Print Sheets", characters_print_path, rel: 'external', target: '_blank' %></li>
+                <li><%= link_to "Experience", storytellers_experience_path %></li>
                 <li><%= link_to "Downtime Periods", storytellers_downtime_periods_path %></li>
                 <li><%= link_to "Downtime Actions", storytellers_downtime_actions_path %></li>
                 <li><%= link_to "Advantages", storytellers_advantages_path %></li>

--- a/app/views/storytellers/dashboard/index.slim
+++ b/app/views/storytellers/dashboard/index.slim
@@ -4,6 +4,8 @@ ul
   li
     = link_to "Print Character Sheets", characters_print_path, target: '_blank'
   li
+    = link_to "Experience", storytellers_experience_path
+  li
     = link_to "Advantages", storytellers_advantages_path
   li
     = link_to "Challenges", storytellers_challenges_path

--- a/app/views/storytellers/experience/index.slim
+++ b/app/views/storytellers/experience/index.slim
@@ -23,7 +23,7 @@ table.table
           td
             = link_to "View", storytellers_show_experience_expenditure_path(expenditure)
           td
-            = form_tag(storytellers_delete_xp_expenditure_path(xprecord), method: 'DELETE') do
+            = form_tag(storytellers_delete_xp_expenditure_record_path(expenditure), method: 'DELETE') do
               = button_tag "Delete", type: 'submit', onClick: 'return confirm("Are you sure you want to delete this experience expenditure?");', class: 'button-text'
 
 
@@ -43,12 +43,12 @@ table.table
       th
   tbody
     - if @records.present?
-      - @records.each do |xprecord|
+      - @records.each do |record|
         tr
-          td #{xprecord.character.name}
-          td #{xprecord.amount}
-          td #{xprecord.description}
-          td #{xprecord.created_at}
+          td #{record.character.name}
+          td #{record.amount}
+          td #{record.description}
+          td #{record.created_at}
           td
-            = form_tag(storytellers_delete_xp_record_path(xprecord), method: 'DELETE') do
+            = form_tag(storytellers_delete_xp_record_path(record), method: 'DELETE') do
               = button_tag "Delete", type: 'submit', onClick: 'return confirm("Are you sure you want to delete this experience record?");', class: 'button-text'

--- a/app/views/storytellers/experience/index.slim
+++ b/app/views/storytellers/experience/index.slim
@@ -4,3 +4,51 @@
 h2 Experience
 
 h3 Expenditures Awaiting Approval
+
+table.table
+  thead
+    tr
+      th Character
+      th Amount Spent
+      th Date Submitted
+      th
+      th
+  tbody
+    - if @expenditures.present?
+      - @expenditures.each do |expenditure|
+        tr
+          td #{expenditure.character.name}
+          td #{expenditure.amount}
+          td #{expenditure.created_at}
+          td
+            = link_to "View", storytellers_show_experience_expenditure_path(expenditure)
+          td
+            = form_tag(storytellers_delete_xp_expenditure_path(xprecord), method: 'DELETE') do
+              = button_tag "Delete", type: 'submit', onClick: 'return confirm("Are you sure you want to delete this experience expenditure?");', class: 'button-text'
+
+
+h3 Experience Records
+
+.button-row.right
+  = link_to "Add Experience", storytellers_new_experience_record_path, class: 'button'
+  = link_to "Mass-Add Experience", storytellers_mass_experience_record_path, class: 'button'
+
+table.table
+  thead
+    tr
+      th Character
+      th Amount
+      th Reason
+      th Date
+      th
+  tbody
+    - if @records.present?
+      - @records.each do |xprecord|
+        tr
+          td #{xprecord.character.name}
+          td #{xprecord.amount}
+          td #{xprecord.description}
+          td #{xprecord.created_at}
+          td
+            = form_tag(storytellers_delete_xp_record_path(xprecord), method: 'DELETE') do
+              = button_tag "Delete", type: 'submit', onClick: 'return confirm("Are you sure you want to delete this experience record?");', class: 'button-text'

--- a/app/views/storytellers/experience/index.slim
+++ b/app/views/storytellers/experience/index.slim
@@ -1,0 +1,6 @@
+.breadcrumbs
+  = render_breadcrumbs
+
+h2 Experience
+
+h3 Expenditures Awaiting Approval

--- a/app/views/storytellers/experience/mass.slim
+++ b/app/views/storytellers/experience/mass.slim
@@ -5,11 +5,11 @@ h2 Add Experience to Active Characters
 
 = form_tag storytellers_mass_assign_experience_path, method: 'POST'
   .form-row
-    = f.label :amount
-    = f.number_field :amount
+    = label_tag :amount
+    = number_field_tag :amount
   .form-row
-    = f.label :description
-    = f.text_field :description
+    = label_tag :description
+    = text_field_tag :description
 
   .button-row
-    = f.submit "Add Experience"
+    = submit_tag "Add Experience"

--- a/app/views/storytellers/experience/mass.slim
+++ b/app/views/storytellers/experience/mass.slim
@@ -1,0 +1,15 @@
+.breadcrumbs
+  = render_breadcrumbs
+
+h2 Add Experience to Active Characters
+
+= form_tag storytellers_mass_assign_experience_path, method: 'POST'
+  .form-row
+    = f.label :amount
+    = f.number_field :amount
+  .form-row
+    = f.label :description
+    = f.text_field :description
+
+  .button-row
+    = f.submit "Add Experience"

--- a/app/views/storytellers/experience/new.slim
+++ b/app/views/storytellers/experience/new.slim
@@ -6,7 +6,7 @@ h2 Add Experience
 = form_for @xpr, url: {action: 'create'} do |f|
   .form-row
     = f.label :character_id, "Character"
-    = f.collection_select :xp_record, :character_id, Character.where(is_npc: false, status: 2), :id, :name
+    = f.collection_select :character_id, Character.where(is_npc: false, status: 2), :id, :name
   .form-row
     = f.label :amount
     = f.number_field :amount

--- a/app/views/storytellers/experience/new.slim
+++ b/app/views/storytellers/experience/new.slim
@@ -1,0 +1,18 @@
+.breadcrumbs
+  = render_breadcrumbs
+
+h2 Add Experience
+
+= form_for @xpr, url: {action: 'create'} do |f|
+  .form-row
+    = f.label :character_id, "Character"
+    = f.collection_select :xp_record, :character_id, Character.where(is_npc: false, status: 2), :id, :name
+  .form-row
+    = f.label :amount
+    = f.number_field :amount
+  .form-row
+    = f.label :description
+    = f.text_field :description
+
+  .button-row
+    = f.submit "Add Experience"

--- a/app/views/storytellers/experience/show.slim
+++ b/app/views/storytellers/experience/show.slim
@@ -1,0 +1,72 @@
+.breadcrumbs
+  = render_breadcrumbs
+
+h2 Experience Expenditure for #{@xpe.character.name}
+
+ul
+  - JSON.parse(@xpe.diff).each do |item, val|
+    - if item != "character_has_advantages" and item != "character_has_challenges"
+      li
+        strong #{item.titleize}
+        = " from "
+        em #{val[0]}
+        = " to "
+        em #{val[1]}
+    - elsif item == "character_has_advantages"
+      - advantages_old = val[0]
+      - advantages_new = val[1]
+      - advantages_removed = advantages_old.select{|ao| advantages_new.index{|an| an['id'] == ao['id']}.nil?}
+      - advantages_updated = advantages_old.reject{|ao| ab = advantages_new.bsearch{|an| an['id'] == ao['id']}; ab.present? ? ab['rating'] == ao['rating'] : true}
+      - advantages_added = advantages_new.select{|an| an['id'].nil?}
+      - unless advantages_removed.empty?
+        - advantages_removed.each do |ar|
+          - advantage = CharacterHasAdvantage.find(ar['id'])
+          li
+            = "Removed "
+            strong #{advantage.advantage.name}#{advantage.specification.present? ? " #{advantage.specification}" : ''} #{advantage.rating}
+      - unless advantages_updated.empty?
+        - advantages_updated.each do |au|
+          - advantage = CharacterHasAdvantage.find(au['id'])
+          li
+            strong #{advantage.advantage.name}#{advantage.specification.present? ? " (#{advantage.specification})" : ''}
+            = " from "
+            em #{advantage.rating}
+            = " to "
+            em #{au['rating']}
+      - unless advantages_added.empty?
+        - advantages_added.each do |aa|
+          - advantage = Advantage.find(aa['advantage_id'])
+          li
+            strong #{advantage.name}#{aa['specification'].present? ? " (#{aa['specification']})" : ''}
+            = " from "
+            em 0
+            = " to "
+            em #{aa['rating']}
+    - elsif item == "character_has_challenges"
+      - challenges_old = val[0]
+      - challenges_new = val[1]
+      - challenges_added = challenges_new.select{|cn| cn['id'].nil?}
+      - challenges_removed = challenges_old.select{|co| challenges_new.index{|cn| cn['id'] == co['id']}.nil?}
+      - unless challenges_removed.empty?
+        - challenges_removed.each do |cr|
+          - challenge = CharacterHasChallenge.find(cr['id'])
+      - unless challenges_added.empty?
+        - challenges_added.each do |ca|
+          - challenge = Challenge.find(ca['challenge_id'])
+          li
+            = "Adding Challenge "
+            - if ca['custom_name'].present?
+              strong #{ca['custom_name']}
+            - else
+              strong #{challenge.name}
+            - if ca['custom_description'].present?
+              .description
+                = raw @markdown.render(ca['custom_description'])
+
+
+p.total
+  strong Total Points Spent:
+  = " #{@xpe.amount}"
+
+= form_tag(storytellers_approve_experience_expenditure_path(params[:id]), method: 'POST') do
+  = submit_tag "Apply Expenditure"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,13 @@ Rails.application.routes.draw do
     resources :true_selves
     post 'reorder_questionnaire', to: 'questionnaire_sections#reorder_sections', as: 'reorder_questionnaire_sections'
     resources :questionnaire_sections
+    get 'experience/new', to: 'experience#new', as: 'new_experience_record'
+    get 'experience/mass', to: 'experience#mass', as: 'mass_experience_record'
+    post 'experience/mass', to: 'experience#mass_assign', as: 'mass_assign_experience'
+    post 'experience/new', to: 'experience#create', as: 'single_assign_experience'
+    get 'experience/:id', to: 'experience#show', as: 'show_experience_expenditure'
+    post 'experience/:id', to: 'experience#approve_expenditure', as: 'approve_experience_expenditure'
+    get 'experience', to: 'experience#index', as: 'experience'
   end
 
   # The priority is based upon order of creation: first created -> highest priority.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   get 'characters/wizard', to: 'characters#wizard', as: 'new_character_wizard'
   get 'characters/print_all', to: 'characters#print_all', as: 'characters_print'
   resources :characters
+  delete 'characters/:id/expenditures/:expenditure_id', to: 'characters#delete_expenditure', as: 'character_delete_xp_expenditure'
   get 'characters/:id/wizard', to: 'characters#wizard', as: 'character_wizard'
   get 'characters/:id/wizard/basics', to: 'characters#wizard_basics'
   get 'characters/:id/wizard/skills_trainings', to: 'characters#wizard_skills_trainings'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,6 +45,8 @@ Rails.application.routes.draw do
     get 'experience/mass', to: 'experience#mass', as: 'mass_experience_record'
     post 'experience/mass', to: 'experience#mass_assign', as: 'mass_assign_experience'
     post 'experience/new', to: 'experience#create', as: 'single_assign_experience'
+    delete 'experience/expenditure/:id', to: 'experience#destroy_expenditure', as: 'delete_xp_expenditure_record'
+    delete 'experience/record/:id', to: 'experience#destroy', as: 'delete_xp_record'
     get 'experience/:id', to: 'experience#show', as: 'show_experience_expenditure'
     post 'experience/:id', to: 'experience#approve_expenditure', as: 'approve_experience_expenditure'
     get 'experience', to: 'experience#index', as: 'experience'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,7 +53,6 @@ Rails.application.routes.draw do
     resources :true_selves
     post 'reorder_questionnaire', to: 'questionnaire_sections#reorder_sections', as: 'reorder_questionnaire_sections'
     resources :questionnaire_sections
-<<<<<<< HEAD
     get 'experience/new', to: 'experience#new', as: 'new_experience_record'
     get 'experience/mass', to: 'experience#mass', as: 'mass_experience_record'
     post 'experience/mass', to: 'experience#mass_assign', as: 'mass_assign_experience'
@@ -63,12 +62,10 @@ Rails.application.routes.draw do
     get 'experience/:id', to: 'experience#show', as: 'show_experience_expenditure'
     post 'experience/:id', to: 'experience#approve_expenditure', as: 'approve_experience_expenditure'
     get 'experience', to: 'experience#index', as: 'experience'
-=======
     get 'downtime_actions/period/:downtime_period_id/print', to: 'downtime_actions#downtime_period_print', as: 'print_downtime_actions_downtime_period'
     get 'downtime_actions/period/:downtime_period_id', to: 'downtime_actions#downtime_period', as: 'downtime_actions_downtime_period'
     resources :downtime_actions, only: [:index, :show, :edit, :update]
     resources :downtime_periods
->>>>>>> master
     get '/settings', to: 'settings#index', as: 'settings'
     post '/settings', to: 'settings#update', as: 'update_settings'
   end

--- a/db/migrate/201701326035599_add_experience_expenditures.rb
+++ b/db/migrate/201701326035599_add_experience_expenditures.rb
@@ -1,0 +1,11 @@
+class AddExperienceExpenditures < ActiveRecord::Migration[5.0]
+  def change
+    create_table :xp_expenditures do |t|
+      t.integer :character_id, null: false
+      t.string :diff
+      t.integer :amount, default: 0
+      t.boolean :is_approved, default: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -51,9 +51,9 @@ ActiveRecord::Schema.define(version: 201702020635481) do
     t.integer  "challenge_id",                          null: false
     t.string   "custom_name"
     t.text     "custom_description"
+    t.boolean  "is_creature_challenge", default: false
     t.datetime "created_at",                            null: false
     t.datetime "updated_at",                            null: false
-    t.boolean  "is_creature_challenge", default: false
     t.index ["challenge_id"], name: "index_character_has_challenges_on_challenge_id", using: :btree
     t.index ["character_id"], name: "index_character_has_challenges_on_character_id", using: :btree
   end
@@ -112,6 +112,31 @@ ActiveRecord::Schema.define(version: 201702020635481) do
     t.index ["user_id"], name: "index_characters_on_user_id", using: :btree
   end
 
+  create_table "downtime_actions", force: :cascade do |t|
+    t.string   "title",                              null: false
+    t.string   "assets"
+    t.boolean  "burn",               default: false
+    t.text     "description",                        null: false
+    t.boolean  "is_submitted",       default: false
+    t.text     "response"
+    t.integer  "downtime_period_id",                 null: false
+    t.integer  "character_id",                       null: false
+    t.datetime "created_at",                         null: false
+    t.datetime "updated_at",                         null: false
+    t.integer  "size",               default: 0
+    t.integer  "status",             default: 0
+    t.integer  "action_type",        default: 0,     null: false
+  end
+
+  create_table "downtime_periods", force: :cascade do |t|
+    t.string   "title"
+    t.boolean  "downtimes_visible"
+    t.datetime "created_at",                        null: false
+    t.datetime "updated_at",                        null: false
+    t.boolean  "downtimes_open",    default: false
+    t.boolean  "is_active",         default: false
+  end
+
   create_table "questionnaire_answers", force: :cascade do |t|
     t.integer  "questionnaire_item_id",              null: false
     t.integer  "character_id",                       null: false
@@ -141,10 +166,10 @@ ActiveRecord::Schema.define(version: 201702020635481) do
   end
 
   create_table "true_selves", force: :cascade do |t|
-    t.string   "name",                     null: false
-    t.datetime "created_at",               null: false
-    t.datetime "updated_at",               null: false
-    t.text     "description", default: ""
+    t.string   "name",        null: false
+    t.text     "description"
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
   end
 
   create_table "users", force: :cascade do |t|
@@ -169,6 +194,15 @@ ActiveRecord::Schema.define(version: 201702020635481) do
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
+  end
+
+  create_table "xp_expenditures", force: :cascade do |t|
+    t.integer  "character_id",                 null: false
+    t.string   "diff"
+    t.integer  "amount",       default: 0
+    t.boolean  "is_approved",  default: false
+    t.datetime "created_at",                   null: false
+    t.datetime "updated_at",                   null: false
   end
 
   create_table "xp_records", force: :cascade do |t|


### PR DESCRIPTION
Closes #66.

Adds an advancement system to the character system!

Storytellers can go to /storytellers/experience to view a) experience expenditures awaiting approval and b) experience records. The experience records section also has two buttons—one to add XP to one character, and one to mass-assign XP to all currently-active characters.

When active characters have a positive experience point balance, they can click a link on their character listing to spend experience. They edit their character sheet, and submit it. The character sheet is not updated, and instead a record is created in the xp_expenditures table that keeps track of the differences.

Back in the storyteller section, the storytellers can see the list of items that the player wants to change on their character sheet, as well as the point total for the expenditures. If it looks fine, they can click a button to approve it, which will automatically apply the changes to the sheet and deduct the experience points.