### PR TITLE
Remove character requirement from questionnaire answers to make it wo…

### DIFF
--- a/app/models/questionnaire_answer.rb
+++ b/app/models/questionnaire_answer.rb
@@ -3,5 +3,5 @@ class QuestionnaireAnswer < ApplicationRecord
 	belongs_to :questionnaire_item
 
 	validates :questionnaire_item, presence: true
-	validates :character, 				 presence: true
+	validates :character
 end

--- a/app/models/questionnaire_answer.rb
+++ b/app/models/questionnaire_answer.rb
@@ -3,5 +3,4 @@ class QuestionnaireAnswer < ApplicationRecord
 	belongs_to :questionnaire_item
 
 	validates :questionnaire_item, presence: true
-	validates :character
 end

--- a/test/models/questionnaire_answer_test.rb
+++ b/test/models/questionnaire_answer_test.rb
@@ -10,9 +10,4 @@ class QuestionnaireAnswerTest < ActiveSupport::TestCase
     test_answer = QuestionnaireAnswer.new(character: characters(:one), answer: "more things")
     assert_not test_answer.valid?
   end
-
-  test "question answers are not valid without character" do
-    test_answer = QuestionnaireAnswer.new(questionnaire_item: questionnaire_items(:one), answer: "an answer")
-    assert_not test_answer.valid?
-  end
 end


### PR DESCRIPTION
…rk with nested attributes

this is what I get for not testing my shit on staging but it's also like 1am. having the character_id be required on questionnaire_answers was making it impossible to assign params before a character was saved and messing up the nested attribute assignment