### PR TITLE
Fix submission from inside wizard + other wizard tweaks

### DIFF
--- a/app/views/characters/wizard.slim
+++ b/app/views/characters/wizard.slim
@@ -9,20 +9,22 @@
     = f.label :name
     = f.text_field :name
 
-  .form-row.build-method
-    label.radio-label.checked
-      p
-        strong Mechanical Proposal
-      = f.radio_button :use_extended, false
+  - if Setting.qualitative_open
+    .form-row.build-method
+      label.radio-label.checked
+        p
+          strong Mechanical Proposal
+        = f.radio_button :use_extended, false
 
-      p I would like to build my character's mechanics myself.
-    label.radio-label
-      p
-        strong Written Proposal
-      = f.radio_button :use_extended, true
+        p I would like to build my character's mechanics myself.
+      label.radio-label
+        p
+          strong Written Proposal
+        = f.radio_button :use_extended, true
 
-      p I would like storyteller assistance in building my character, and am willing to answer a few extra questions about it.
-
+        p I would like storyteller assistance in building my character, and am willing to answer a few extra questions about it.
+  - else
+    = f.hidden_field :use_extended, {value: false}
 
   - if @section.present?
 

--- a/app/views/characters/wizard_challenges_advantages.slim
+++ b/app/views/characters/wizard_challenges_advantages.slim
@@ -17,7 +17,7 @@
       = button_tag 'Add', type: 'button', class: 'button-secondary', id: "advantage-add"
 
     ul#advantages-list
-      - @character.character_has_advantages_attributes.each do |advantage|
+      - @character.character_has_advantages.each do |advantage|
         li data-id="#{advantage.id}" data-rating="#{advantage.rating}" data-specification="#{advantage.specification}" data-advantage-id="#{advantage.advantage.id}"
           = "#{advantage.advantage.name} "
           - if advantage.advantage.requires_specification
@@ -52,7 +52,7 @@
 
 
     ul#challenges-list
-      - @character.character_has_challenges_attributes.each do |challenge|
+      - @character.character_has_challenges.each do |challenge|
         li
           - if challenge.challenge.is_custom
             - if challenge.custom_name.present?
@@ -83,12 +83,14 @@
     = hidden_field_tag "wizard_prev", "skills_trainings"
     = hidden_field_tag "wizard", "full"
     = f.hidden_field :id
+    = f.hidden_field :status
 
     .button-row
       = hidden_field_tag "formaction", "", id: 'form-action'
       = f.submit "Back", id: 'back'
       = f.submit "Save", id: 'save'
-      = f.submit "Finish", id: 'finish'
+      - if @character.status == 0 and Setting.quantitative_open
+        = f.submit "Finish", id: 'save-submit'
 
   .overlay#advantages-overlay
     .modal

--- a/app/views/characters/wizard_questionnaire.slim
+++ b/app/views/characters/wizard_questionnaire.slim
@@ -48,7 +48,7 @@
     = hidden_field_tag "wizard_current", @page.id
     = hidden_field_tag "wizard_prev", @page.id-1
     = hidden_field_tag "wizard", @questionnaire.length > @page.id ? @page.id+1 : 'basics'
-
+    = f.hidden_field :status
     .button-row
       = hidden_field_tag "formaction", "", id: 'form-action'
       - if @questionnaire.first.id != @page.id


### PR DESCRIPTION
Fixes the following:

* Submitting from inside the wizard wasn't working because the pages w/ the submit button didn't have the status field present, which gets updated before submission
* The advantages/challenges page had a variable error that was causing some problems
* When qualitative_open is false, don't show the option to choose extended vs mechanics on the first page of the wizard