### PR TITLE
[190][191][192] Character Submission Improvements

### DIFF
--- a/app/assets/stylesheets/components/_buttons.scss
+++ b/app/assets/stylesheets/components/_buttons.scss
@@ -26,6 +26,11 @@
 
   &[disabled] {
     background-color: $silver;
+
+    &:hover, &:focus {
+      background-color: $silver;
+      color: $white;
+    }
   }
 }
 

--- a/app/assets/stylesheets/components/_buttons.scss
+++ b/app/assets/stylesheets/components/_buttons.scss
@@ -23,6 +23,10 @@
     color: $green;
     background-color: $white;
   }
+
+  &[disabled] {
+    background-color: $silver;
+  }
 }
 
 .button-secondary {

--- a/app/controllers/characters_controller.rb
+++ b/app/controllers/characters_controller.rb
@@ -99,6 +99,13 @@ class CharactersController < ApplicationController
 			flash[:success] = "Experience expenditure for #{@character.name} submitted."
 			redirect_to character_path(@character) and return
 		end
+		if @character.status == 0 and ((@character.use_extended and !Settings.qualitative_open) or !Settings.quantitative_open)
+			# set status to In Progress even if they submitted
+			params[:character][:status] = 0
+			@character.update_attributes(characters_params)
+			flash[:error] = "Submissions of this type are currently closed. Your character sheet has been saved, but not submitted."
+			redirect_to character_path(@character) and return
+		end
 		if @character.update_attributes!(characters_params)
 			flash[:success] = "Changes to your character were saved."
 			# send mailers if necessary
@@ -109,6 +116,7 @@ class CharactersController < ApplicationController
 					@storytellers.each do |storyteller|
 						CharacterMailer.character_submission(@character, storyteller).deliver_now
 					end
+					CharacterMailer.character_submission_receipt(@character).deliver_now
 				end
 			end
 			if params[:wizard].present?

--- a/app/mailers/character_mailer.rb
+++ b/app/mailers/character_mailer.rb
@@ -9,6 +9,15 @@ class CharacterMailer < ActionMailer::Base
       :from => 'sts@askagainlater.com')
 	end
 
+	def character_submission_receipt(character)
+		@character = character
+		mail(
+			:subject => "[AAL Character System] Receipt for your character submission: \"#{@character.name}\"",
+			:to => @character.user.email,
+			:from => 'sts@askagainlater.com'
+		)
+	end
+
 	def character_approval(character)
 		@character = character
 		@user = @character.user

--- a/app/views/character_mailer/character_submission_receipt.html.erb
+++ b/app/views/character_mailer/character_submission_receipt.html.erb
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <style type="text/css">
+    body {
+      text-align: center;
+      margin: 50px auto;
+      background-color: #aebfaf;
+      font-size: 16px;
+      font-family: "Lucida Grande", Arial, sans-serif;
+    }
+
+    a {
+      color: #5C7A6A;
+    }
+
+    table {
+      margin: 0 auto;
+    }
+
+    .content-header {
+      height: 60px;
+      text-align: left;
+      padding: 0 30px;
+    }
+
+    h1 {
+      font-size: 36px;
+      line-height: 36px;
+      color: #FFFFFF;
+      font-family: "Palatino", "Georgia", "Times New Roman", serif;
+      margin: 0;
+    }
+
+    h1 a {
+      color: #FFFFFF;
+      text-decoration: none;
+      font-weight: normal;
+    }
+
+    h2 {
+      font-family: "Palatino", "Georgia", "Times New Roman", serif;
+      margin-top: 0;
+    }
+
+    .content-body {
+      padding: 30px;
+      text-align: left;
+    }
+  </style>
+  <body>
+    <table cellpadding="0" cellspacing="0" border="0" width="600">
+      <tr>
+        <td bgcolor="#333333" color="#FFFFFF" class="content-header" height="60" valign="middle">
+          <h1><a href="<%= root_url %>">AAL Character System</a></h1>
+        </td>
+      </tr>
+      <tr>
+        <td bgcolor="#FFFFFF" color="#333333" class="content-body">
+          <h2>Your character submission: <%= @character.name %></h2>
+          <p>Hi, <%= @character.user.name %>!</p>
+          <p>Thanks for your character submission, "<%= @character.name %>." To view your submission, <a href="<%= root_url %>characters/<%= @character.id %>">click here</a>.</p>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/app/views/character_mailer/character_submission_receipt.txt.erb
+++ b/app/views/character_mailer/character_submission_receipt.txt.erb
@@ -1,0 +1,5 @@
+Your character submission: <%= @character.name %>
+
+Hi, <%= @character.user.name %>!
+
+Thanks for your character submission, "<%= @character.name %>." To view your submission, click here: <%= root_url %>characters/<%= @character.id %>

--- a/app/views/characters/_form.slim
+++ b/app/views/characters/_form.slim
@@ -187,6 +187,11 @@
     - if @character.status == 0 and (current_user == @character.user or @character.user.nil?) and !current_user.is_storyteller and ((Setting.qualitative_open and @character.use_extended) or (Setting.quantitative_open and !@character.use_extended))
       = f.hidden_field :status
       = f.submit "Save and Submit", id: 'save-submit'
+    - elsif @character.status == 0 and current_user == @character.user
+      - if @character.use_extended and !Setting.qualitative_open
+        = f.submit "Extended Written Proposals Closed", id: 'save-submit', disabled: true
+      - elsif !Setting.quantitative_open
+        = f.submit "Mechanical Proposals Closed", id: 'save-submit', disabled: true
 
   .overlay#advantages-overlay
     .modal

--- a/app/views/characters/wizard_challenges_advantages.slim
+++ b/app/views/characters/wizard_challenges_advantages.slim
@@ -91,6 +91,8 @@
       = f.submit "Save", id: 'save'
       - if @character.status == 0 and Setting.quantitative_open
         = f.submit "Finish", id: 'save-submit'
+      - else
+        = f.submit "Mechanical Proposals Closed", id: 'save-submit', disabled: true
 
   .overlay#advantages-overlay
     .modal

--- a/app/views/characters/wizard_questionnaire.slim
+++ b/app/views/characters/wizard_questionnaire.slim
@@ -60,6 +60,8 @@
       - else
         - if @character.status == 0 and Setting.qualitative_open
           = f.submit "Save and Submit", id: 'save-submit'
+        - else
+          = f.submit "Extended Written Proposals Closed", id: 'save-submit', disabled: true
 
   = javascript_include_tag 'wizard'
   = javascript_include_tag 'characters'


### PR DESCRIPTION
Closes #190.
Closes #191.
Closes #192.

Mails the submitting user a receipt of their character submission on successful submit. Also makes it impossible to submit a character after submissions are closed, even if the user is still able to click the submit button. Lastly, replaces the "missing" submit buttons with disabled buttons when the corresponding submission types are closed.