### PR TITLE
[83] Add conditional paging plugin when paging is unnecessary

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,6 +14,7 @@
 //= require jquery_ujs
 //= require jquery-ui
 //= require dataTables/jquery.dataTables
+//= require dataTables.conditionalPaging
 //= require showdown
 //= require nestedSortable
 //= require common

--- a/app/assets/javascripts/dataTables.conditionalPaging.js
+++ b/app/assets/javascripts/dataTables.conditionalPaging.js
@@ -1,0 +1,82 @@
+/**
+ * @summary     ConditionalPaging
+ * @description Hide paging controls when the amount of pages is <= 1
+ * @version     1.0.0
+ * @file        dataTables.conditionalPaging.js
+ * @author      Matthew Hasbach (https://github.com/mjhasbach)
+ * @contact     hasbach.git@gmail.com
+ * @copyright   Copyright 2015 Matthew Hasbach
+ *
+ * License      MIT - http://datatables.net/license/mit
+ *
+ * This feature plugin for DataTables hides paging controls when the amount
+ * of pages is <= 1. The controls can either appear / disappear or fade in / out
+ *
+ * @example
+ *    $('#myTable').DataTable({
+ *        conditionalPaging: true
+ *    });
+ *
+ * @example
+ *    $('#myTable').DataTable({
+ *        conditionalPaging: {
+ *            style: 'fade',
+ *            speed: 500 // optional
+ *        }
+ *    });
+ */
+
+(function(window, document, $) {
+    $(document).on('init.dt', function(e, dtSettings) {
+        if ( e.namespace !== 'dt' ) {
+            return;
+        }
+
+        var options = dtSettings.oInit.conditionalPaging || $.fn.dataTable.defaults.conditionalPaging;
+
+        if ($.isPlainObject(options) || options === true) {
+            var config = $.isPlainObject(options) ? options : {},
+                api = new $.fn.dataTable.Api(dtSettings),
+                speed = 'slow',
+                conditionalPaging = function(e) {
+                    var $paging = $(api.table().container()).find('div.dataTables_paginate'),
+                        pages = api.page.info().pages;
+
+                    if (e instanceof $.Event) {
+                        if (pages <= 1) {
+                            if (config.style === 'fade') {
+                                $paging.stop().fadeTo(speed, 0);
+                            }
+                            else {
+                                $paging.css('visibility', 'hidden');
+                            }
+                        }
+                        else {
+                            if (config.style === 'fade') {
+                                $paging.stop().fadeTo(speed, 1);
+                            }
+                            else {
+                                $paging.css('visibility', '');
+                            }
+                        }
+                    }
+                    else if (pages <= 1) {
+                        if (config.style === 'fade') {
+                            $paging.css('opacity', 0);
+                        }
+                        else {
+                            $paging.css('visibility', 'hidden');
+                        }
+                    }
+                };
+
+            if ($.isNumeric(config.speed) || $.type(config.speed) === 'string') {
+                speed = config.speed;
+            }
+
+            conditionalPaging();
+
+            api.on('draw.dt', conditionalPaging);
+        }
+    });
+})(window, document, jQuery);

--- a/app/assets/javascripts/footer.js
+++ b/app/assets/javascripts/footer.js
@@ -1,5 +1,7 @@
 $(document).ready(function() {
-  $('.table').dataTable();
+  $('.table').dataTable({
+    conditionalPaging: true
+  });
 
   $('textarea').wrap('<div class="textarea-wrapper"></div>');
   $('.textarea-wrapper').append('<span class="notice">You can use <a href="https://guides.github.com/features/mastering-markdown/" rel="external" target="_blank">Markdown</a> in this area.</span>');


### PR DESCRIPTION
Closes #83.

Adds the conditional paging plugin for datatables, which will automatically hide the pagination on a datatables instance when there is only one page.