### PR TITLE
[39] print stability score on character sheet.

### DIFF
--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -37,6 +37,25 @@ h2 {
     .mod {
       text-align: center;
     }
+
+    &.stability {
+      align-items: center;
+    }
+  }
+  .ico-stability {
+    i {
+      color: $white;
+      font-size: 20px;
+      text-shadow: -1px -1px 0 $black, 1px 1px 0 $black, 1px -1px 0 $black, -1px 1px 0 $black;
+    }
+
+    &.current {
+      i {
+        color: $black;
+        font-size: 32px;
+        text-shadow: none;
+      }
+    }
   }
   .column-content {
     columns: 2;

--- a/app/views/characters/_print_sheet.slim
+++ b/app/views/characters/_print_sheet.slim
@@ -23,17 +23,24 @@ h2 #{character.name}
       .row
         strong
           = "Stability"
-          .boxes
+        .stability-content
+          .boxes.stability
             - character.stability.times do |i|
               .box
-                .ico-stability
-        .stability-modifiers
-          - if character.stability > 4
-            .mod +#{character.stability - 4} to mundane perception
-            .mod -#{character.stability - 4} to unnatural perception
-          - elsif character.stability < 4
-            .mod -#{4 - character.stability} to mundane perception
-            .mod +#{4 - character.stability} to unnatural perception
+                - if i == character.stability-1
+                  .ico-stability.current
+                    i.fa.fa-certificate
+                - else
+                  .ico-stability
+                    i.fa.fa-certificate
+
+          .stability-modifiers
+            - if character.stability > 4
+              .mod +#{character.stability - 4} to mundane perception
+              .mod -#{character.stability - 4} to unnatural perception
+            - elsif character.stability < 4
+              .mod -#{4 - character.stability} to mundane perception
+              .mod +#{4 - character.stability} to unnatural perception
       .row
         strong Willpower
         .boxes


### PR DESCRIPTION
Closes #39.

Dependent on 64-npcs and 40-print-stability-modifiers. Prints the stability score using fa-certificate and some styling to make the current score stand out.