### PR TITLE
Need to change :edit to :account_update to allow updating of user name

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,7 +9,7 @@ class ApplicationController < ActionController::Base
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
-    devise_parameter_sanitizer.permit(:edit, keys: [:name])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:name])
   end
 
   def requires_storyteller


### PR DESCRIPTION
Needed to use :account_update instead of :edit in the devise_parameter_sanitizer call in application_controller to allow users to _update_ their name on their account. Whoops!