### PR TITLE
Fix DB migrations for production

### DIFF
--- a/db/migrate/20170507154522_create_equipment.rb
+++ b/db/migrate/20170507154522_create_equipment.rb
@@ -1,6 +1,6 @@
 class CreateEquipment < ActiveRecord::Migration[5.0]
   def change
-    create_table :equipments do |t|
+    create_table :equipment do |t|
       t.string :name, null: false
       t.integer :size
       t.integer :durability

--- a/db/migrate/201712020230224_fix_equipment_table_name.rb
+++ b/db/migrate/201712020230224_fix_equipment_table_name.rb
@@ -1,5 +1,0 @@
-class FixEquipmentTableName < ActiveRecord::Migration[5.0]
-  def change
-    rename_table :equipments, :equipment
-  end
-end


### PR DESCRIPTION
Had to add an extra db migration to fix something on staging; now deleting that migration and renaming the create_table call for running migrations on production.