### PR TITLE
Update Character Sheet Look & Feel

### DIFF
--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -11,8 +11,20 @@ body {
   font-family: 'Roboto', sans-serif;
 }
 
+h2, h3 {
+  text-align: left;
+}
+
 h2 {
-  text-align: center;
+  border-color: black;
+  padding-bottom: 10px;
+}
+
+h3 {
+  border-bottom: 3px solid $black;
+  display: inline-block;
+  padding-right: 24px;
+  position: relative;
 }
 
 .sheet {
@@ -62,6 +74,49 @@ h2 {
 
     .column-item {
       break-inside: avoid;
+    }
+  }
+
+  .advantages {
+    page-break-inside: avoid;
+    ul {
+      columns: 200px 2;
+
+      li {
+        break-inside: avoid;
+
+        .name {
+          font-weight: bold;
+        }
+
+        ul {
+          list-style: disc;
+          margin-left: 2em;
+          margin-top: .5em;
+          li {
+            margin-bottom: 0 !important;
+          }
+        }
+      }
+    }
+  }
+}
+
+.flex-container {
+  display: flex;
+  flex-wrap: nowrap;
+
+  .column {
+    .row {
+      padding: 0;
+    }
+  }
+
+  &#skills, &#attributes {
+    .column {
+      max-width: 33%;
+      flex-grow: 0;
+      min-width: 300px;
     }
   }
 }

--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -100,6 +100,14 @@ h3 {
       }
     }
   }
+
+  .challenges {
+    page-break-inside: avoid;
+  }
+
+  .additional-info-wrapper {
+    page-break-inside: avoid;
+  }
 }
 
 .flex-container {

--- a/app/views/characters/_print_npc_sheet.slim
+++ b/app/views/characters/_print_npc_sheet.slim
@@ -113,8 +113,9 @@ h3 Motivation
             p.desc
               = raw markdown.render(chc.challenge.description)
 
-  - if character.additional_info.present?
-    h3 Additional Information
+  .additional-info-wrapper
+    - if character.additional_info.present?
+      h3 Additional Information
 
-    .additional-info
-      = raw markdown.render(character.additional_info)
+      .additional-info
+        = raw markdown.render(character.additional_info)

--- a/app/views/characters/_print_npc_sheet.slim
+++ b/app/views/characters/_print_npc_sheet.slim
@@ -85,24 +85,24 @@ h3 Motivation
       = "Special Training: "
     = skills_training[:"Special Training"].reject{|st|eval("character.#{st.parameterize('_')}") == 0}.map{|s| s+" "+eval("character.#{s.parameterize('_')}").to_s }.join(", ")
 
-  .flex-container
-    .column
-      h3 Advantages
+  .advantages
+    h3 Advantages
 
-      ul#advantages
-        - character.character_has_advantages.group_by{|adv| adv.advantage_id}.each do |k, group|
-          - group.each_with_index do |cha, i|
-            li
-              p.name
-                = cha.advantage.name
-                - if cha.advantage.requires_specification?
-                  = " (#{cha.specification})"
-                - if cha.advantage.allowed_ratings.length > 1
-                  = " #{cha.rating}"
-              - if i == group.length-1
-                p.desc
-                  = raw markdown.render(cha.advantage.description)
-    .column
+    ul#advantages
+      - character.character_has_advantages.group_by{|adv| adv.advantage_id}.each do |k, group|
+        - group.each_with_index do |cha, i|
+          li
+            p.name
+              = cha.advantage.name
+              - if cha.advantage.requires_specification?
+                = " (#{cha.specification})"
+              - if cha.advantage.allowed_ratings.length > 1
+                = " #{cha.rating}"
+            - if i == group.length-1
+              p.desc
+                = raw markdown.render(cha.advantage.description)
+  - if character.challenges.present?
+    .challenges
       h3 Challenges
 
       ul#advantages
@@ -113,7 +113,8 @@ h3 Motivation
             p.desc
               = raw markdown.render(chc.challenge.description)
 
-  h3 Additional Information
+  - if character.additional_info.present?
+    h3 Additional Information
 
-  .additional-info
-    = raw markdown.render(character.additional_info)
+    .additional-info
+      = raw markdown.render(character.additional_info)

--- a/app/views/characters/_print_sheet.slim
+++ b/app/views/characters/_print_sheet.slim
@@ -71,7 +71,7 @@ h2 #{character.name}
 
   h3.attributes Attributes
 
-  .flex-container
+  .flex-container#attributes
     - attributes.each do |cat, vals|
       .column
         strong
@@ -89,7 +89,7 @@ h2 #{character.name}
 
   h3.skills-training Skills and Special Training
 
-  .flex-container
+  .flex-container#skills
     - skills_training.each do |cat, vals|
       .column
         strong
@@ -105,24 +105,24 @@ h2 #{character.name}
               - (5-eval("character.#{val.parameterize("_")}")).times do
                 = icon 'circle-o'
 
-  .flex-container
-    .column
-      h3 Advantages
+  .advantages
+    h3 Advantages
 
-      ul#advantages
-        - character.character_has_advantages.group_by{|adv| adv.advantage_id}.each do |k, group|
-          - group.each_with_index do |cha, i|
-            li
-              p.name
-                = cha.advantage.name
-                - if cha.advantage.requires_specification?
-                  = " (#{cha.specification})"
-                - if cha.advantage.allowed_ratings.length > 1
-                  = " #{cha.rating}"
-              - if i == group.length-1
-                p.desc
-                  = raw markdown.render(cha.advantage.description)
-    .column
+    ul#advantages
+      - character.character_has_advantages.group_by{|adv| adv.advantage_id}.each do |k, group|
+        - group.each_with_index do |cha, i|
+          li
+            p.name
+              = cha.advantage.name
+              - if cha.advantage.requires_specification?
+                = " (#{cha.specification})"
+              - if cha.advantage.allowed_ratings.length > 1
+                = " #{cha.rating}"
+            - if i == group.length-1
+              p.desc
+                = raw markdown.render(cha.advantage.description)
+  - if character.challenges.length > 0
+    .challenges
       h3 Challenges
 
       ul#advantages
@@ -133,5 +133,6 @@ h2 #{character.name}
             p.desc
               = raw markdown.render(chc.challenge.description)
 
-.additional-info
-  = raw markdown.render(character.additional_info)
+- if character.additional_info.present?
+  .additional-info
+    = raw markdown.render(character.additional_info)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 201712020230225) do
+ActiveRecord::Schema.define(version: 201712020320226) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -121,33 +121,35 @@ ActiveRecord::Schema.define(version: 201712020230225) do
   end
 
   create_table "characters_rituals", force: :cascade do |t|
-    t.integer "character_id"
-    t.integer "ritual_id"
+    t.integer  "character_id"
+    t.integer  "ritual_id"
+    t.datetime "created_at",   null: false
+    t.datetime "updated_at",   null: false
   end
 
   create_table "downtime_actions", force: :cascade do |t|
     t.string   "title",                              null: false
     t.string   "assets"
+    t.integer  "action_type",        default: 1,     null: false
+    t.integer  "size",               default: 0
     t.boolean  "burn",               default: false
     t.text     "description",                        null: false
     t.boolean  "is_submitted",       default: false
     t.text     "response"
     t.integer  "downtime_period_id",                 null: false
     t.integer  "character_id",                       null: false
+    t.integer  "status",             default: 0
     t.datetime "created_at",                         null: false
     t.datetime "updated_at",                         null: false
-    t.integer  "size",               default: 0
-    t.integer  "status",             default: 0
-    t.integer  "action_type",        default: 0,     null: false
   end
 
   create_table "downtime_periods", force: :cascade do |t|
     t.string   "title"
-    t.boolean  "downtimes_visible"
+    t.boolean  "is_active",         default: false
+    t.boolean  "downtimes_open",    default: false
+    t.boolean  "downtimes_visible", default: false
     t.datetime "created_at",                        null: false
     t.datetime "updated_at",                        null: false
-    t.boolean  "downtimes_open",    default: false
-    t.boolean  "is_active",         default: false
   end
 
   create_table "equipment", force: :cascade do |t|
@@ -205,12 +207,12 @@ ActiveRecord::Schema.define(version: 201712020230225) do
   end
 
   create_table "rituals", force: :cascade do |t|
+    t.string "name"
     t.string "principle"
     t.string "trappings"
     t.string "focus"
     t.text   "effect"
     t.string "duration"
-    t.string "name"
   end
 
   create_table "settings", force: :cascade do |t|


### PR DESCRIPTION
Updates the character sheet look and feel with some visual improvements. Skills and Special Training should now always be on page 1; Advantages breaks to page 2 if it cannot fit entirely on page 1. Challenges and Additional Info only display if necessary. Examples below.

![yogg-test](https://user-images.githubusercontent.com/267841/27504097-0261d324-584a-11e7-891c-0bd2ac6e5ad5.jpg)
![yogg-test-2](https://user-images.githubusercontent.com/267841/27504098-02777828-584a-11e7-9782-4d646206bfab.jpg)

![jenna-test](https://user-images.githubusercontent.com/267841/27504208-50d99ab8-584b-11e7-867b-565ca6267417.jpg)
[jenna-test-2.pdf](https://github.com/ask-again-later/character-system/files/1099293/jenna-test-2.pdf)
