### PR TITLE
require user authentication before downtime action routes

### DIFF
--- a/app/controllers/downtime_actions_controller.rb
+++ b/app/controllers/downtime_actions_controller.rb
@@ -1,4 +1,6 @@
 class DowntimeActionsController < ApplicationController
+  before_action :authenticate_user!
+
   ACTION_TYPE_ENUM = [["Preserve", 1], ["Change", 2], ["Gather Knowledge", 3], ["Personal Errand", 4]]
 
   def index


### PR DESCRIPTION
Runs the authenticate_user! filter before any of the methods in the characters > downtime_actions controller so that non-logged-in users will be redirected to the login screen.