### PR TITLE
Adjust display of edit buttons on character sheet

### DIFF
--- a/app/views/characters/_sheet.slim
+++ b/app/views/characters/_sheet.slim
@@ -1,8 +1,12 @@
 h2
   = "Character: #{character.name}"
 
-.button-row.right
-  = link_to "Edit in Wizard", character_wizard_page_path(@character, 1), class: 'button'
+- if @character.current_xp > 0 && @character.status > 0 && !current_user.is_storyteller
+  .button-row.right
+    = link_to "Edit in Wizard", character_wizard_page_path(@character, 1), class: 'button'
+- if current_user.is_storyteller
+  .button-row.right
+    = link_to "Edit Character", edit_character_path(@character), class: 'button'
 
 
 ul.tabs
@@ -111,7 +115,7 @@ section#mechanics.show
     .stat.stability
       strong Stability:
       = character.stability
-      
+
     .stat.willpower
       strong Willpower:
       = character.willpower

--- a/app/views/characters/_sheet.slim
+++ b/app/views/characters/_sheet.slim
@@ -1,9 +1,13 @@
 h2
   = "Character: #{character.name}"
 
-- if @character.current_xp > 0 && @character.status > 0 && !current_user.is_storyteller
+- if @character.status == 0 && !current_user.is_storyteller
   .button-row.right
     = link_to "Edit in Wizard", character_wizard_page_path(@character, 1), class: 'button'
+    = link_to "Edit Full Sheet", edit_character_path(@character), class: 'button'
+- elsif @character.current_xp > 0 && !current_user.is_storyteller
+  .button-row.right
+    = link_to "Spend Experience", edit_character_path(@character), class: 'button'
 - if current_user.is_storyteller
   .button-row.right
     = link_to "Edit Character", edit_character_path(@character), class: 'button'


### PR DESCRIPTION
On the display version of the character sheet, buttons will now show under the following circumstances:

* When a sheet is "In Progress", player should see "Edit in Wizard" and "Edit Full Sheet"
* When a character is any other status than "In Progress", player should see "Spend Experience" when they have a positive experience point balance.
* When a storyteller is logged in, they should always see "Edit Character."