### PR TITLE
Update for downtime system

### DIFF
--- a/app/controllers/downtime_actions_controller.rb
+++ b/app/controllers/downtime_actions_controller.rb
@@ -95,6 +95,6 @@ class DowntimeActionsController < ApplicationController
   private
 
   def downtime_action_params
-    params.require(:downtime_action).permit(:title, :assets, :size, :description, :burn, :response, :downtime_period_id, :character_id, :action_type)
+    params.require(:downtime_action).permit(:title, :assets, :size, :description, :burn, :response, :downtime_period_id, :character_id, :action_type, :notes, :goal)
   end
 end

--- a/app/controllers/downtime_actions_controller.rb
+++ b/app/controllers/downtime_actions_controller.rb
@@ -8,18 +8,14 @@ class DowntimeActionsController < ApplicationController
     unless @character.user == current_user or current_user.is_storyteller
       redirect_to root_path and return
     end
-    if @character.user == current_user
-      @downtime_periods = DowntimePeriod.where(is_active: true).order(id: :desc)
-    else
-      # don't show unfinished actions to storytellers
-      @downtime_periods = DowntimePeriod.where(is_active: true).order(id: :desc)
-    end
+    @downtime_periods = DowntimePeriod.where(is_active: true).order(id: :desc)
+
     @action_types = ACTION_TYPE_ENUM
   end
 
   def show
     @downtime_action = DowntimeAction.find(params[:id])
-    unless @downtime_action.character.user == current_user or (current_user.is_storyteller and @downtime_action.status == 1)
+    unless @downtime_action.character.user == current_user or current_user.is_storyteller
       redirect_to root_path and return
     end
   end

--- a/app/controllers/storytellers/downtime_actions_controller.rb
+++ b/app/controllers/storytellers/downtime_actions_controller.rb
@@ -17,7 +17,7 @@ module Storytellers
 
     def downtime_period
       @downtime_period = DowntimePeriod.find(params[:downtime_period_id])
-      @downtime_actions = DowntimeAction.where(downtime_period_id: params[:downtime_period_id], status: 1)
+      @downtime_actions = DowntimeAction.where(downtime_period_id: params[:downtime_period_id])
       @action_types = ACTION_TYPE_ENUM
   		renderer = Redcarpet::Render::HTML.new(no_links: true, hard_wrap: true, filter_html: true)
   		@markdown = Redcarpet::Markdown.new(renderer, extensions = {})
@@ -26,7 +26,7 @@ module Storytellers
 
     def downtime_period_print
       @downtime_period = DowntimePeriod.find(params[:downtime_period_id])
-      @downtime_actions = DowntimeAction.where(downtime_period_id: params[:downtime_period_id], status: 1)
+      @downtime_actions = DowntimeAction.where(downtime_period_id: params[:downtime_period_id])
       renderer = Redcarpet::Render::HTML.new(no_links: true, hard_wrap: true, filter_html: true)
       @markdown = Redcarpet::Markdown.new(renderer, extensions = {})
   		render layout: 'print'

--- a/app/views/downtime_actions/_form.slim
+++ b/app/views/downtime_actions/_form.slim
@@ -16,8 +16,16 @@
     = f.select :size, options_for_select([["Regular", 0], ["Large", 1]])
 
   .form-row
+    = f.label :goal
+    = f.text_field :goal
+
+  .form-row
     = f.label :description
     = f.text_area :description
+
+  .form-row
+    = f.label :notes, "Notes for Storytellers"
+    = f.text_field :notes
 
   .form-row
     = f.label :burn, "Burn down your life for this action?"

--- a/app/views/downtime_actions/index.slim
+++ b/app/views/downtime_actions/index.slim
@@ -6,15 +6,14 @@ h2 #{@character.name}: Downtime Actions
     .downtime-period
       h3 #{downtime_period.title}
 
+      - unless downtime_period.downtimes_open
+      
+        center Downtimes for this period are closed.
+
       - if downtime_period.downtimes_open and @character.status == 2
         .button-row.right
-          - if @character.downtime_actions.where(downtime_period_id: downtime_period.id, status: 1).present? and downtime_period.downtimes_open
-            = form_tag(character_reopen_downtime_actions_path(@character, downtime_period))
-              = button_tag "Reopen Downtime Actions", type: 'submit', class: 'button'
-          - elsif downtime_period.downtimes_open
-            = link_to "New Downtime Action", new_character_downtime_period_downtime_action_path(@character, downtime_period), class: 'button'
-            = form_tag(character_submit_downtime_actions_path(@character, downtime_period))
-              = button_tag "Submit Downtime Actions", type: 'submit', class: 'button'
+          = link_to "New Downtime Action", new_character_downtime_period_downtime_action_path(@character, downtime_period), class: 'button'
+
       .downtime-action
         - if @character.downtime_actions.where(downtime_period_id: downtime_period.id)
           - @character.downtime_actions.where(downtime_period_id: downtime_period.id).each do |action|

--- a/app/views/storytellers/downtime_actions/_form.slim
+++ b/app/views/storytellers/downtime_actions/_form.slim
@@ -3,17 +3,29 @@
   p
     strong #{"Action Type: "}
     = @action_types[@downtime_action.action_type-1][0]
+
   p
     strong #{"Size: "}
     = @downtime_action.size == 1 ? 'Large' : 'Regular'
+
   p
     strong #{"Assets: "}
     = @downtime_action.assets
+
+  p
+    strong #{"Goal: "}
+    = @downtime_action.goal
+
   p
     strong #{"Burning down life? "}
     = @downtime_action.burn ? 'Yes' : 'No'
+
   .action-description
     = @downtime_action.description
+
+  p
+    strong #{"Notes for Storytellers: "}
+    = @downtime_action.notes
 
   .form-row
     = f.label :response

--- a/db/migrate/201712020320227_add_new_fields_to_downtimes.rb
+++ b/db/migrate/201712020320227_add_new_fields_to_downtimes.rb
@@ -1,0 +1,6 @@
+class AddNewFieldsToDowntimes < ActiveRecord::Migration[5.0]
+  def change
+    add_column :downtime_actions, :goal, :string, default: ''
+    add_column :downtime_actions, :notes, :string, default: ''
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 201712020320226) do
+ActiveRecord::Schema.define(version: 201712020320227) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -141,6 +141,8 @@ ActiveRecord::Schema.define(version: 201712020320226) do
     t.integer  "status",             default: 0
     t.datetime "created_at",                         null: false
     t.datetime "updated_at",                         null: false
+    t.string   "goal",               default: ""
+    t.string   "notes",              default: ""
   end
 
   create_table "downtime_periods", force: :cascade do |t|


### PR DESCRIPTION
1. Changes downtime workflow to remove submission step due to the fact that it's clearly confusing to players from a UX perspective
2. Adds "goal" and "notes" string fields to downtime actions to push clarification of a single-line goal and allow players to note small things like "gave location of weird pedestal in woods to Albert", etc.
3. Adds messaging that displays that a downtime period is closed once it's been set to closed